### PR TITLE
Python integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ install:
   - sudo ./quickstart/deps.sh
 
 script:
-  - sudo make test-all
+  - sudo make 

--- a/Makefile
+++ b/Makefile
@@ -8,52 +8,9 @@ POOL_FILES = $(shell find cache-entry)
 
 TEST_CLUSTER=testing/test-cluster
 KILL_WORKER=./bin/admin kill -cluster=$(TEST_CLUSTER);rm -rf $(TEST_CLUSTER)/workers/*
-RUN_LAMBDA=curl -XPOST localhost:8080/runLambda
-
-STARTUP_PKGS='{"startup_pkgs": ["parso", "jedi", "urllib3", "idna", "chardet", "certifi", "requests", "simplejson"]}'
-REGISTRY_DIR='{"registry_dir": "$(abspath testing/registry)"}'
-
-SOCK_NOCACHE='{"sandbox": "sock", "handler_cache_size": 0, "import_cache_size": 0, "cg_pool_size": 10}'
-SOCK_HANDLER='{"sandbox": "sock", "handler_cache_size": 10000000, "import_cache_size": 0, "cg_pool_size": 10}'
-SOCK_IMPORT='{"sandbox": "sock", "handler_cache_size": 0, "import_cache_size": 10000000, "cg_pool_size": 10}'
-SOCK_BOTH='{"sandbox": "sock", "handler_cache_size": 10000000, "import_cache_size": 10000000, "cg_pool_size": 10}'
-
-DOCKER_NOCACHE='{"sandbox": "docker", "handler_cache_size": 0, "import_cache_size": 0, "cg_pool_size": 0}'
-DOCKER_HANDLER='{"sandbox": "docker", "handler_cache_size": 10000000, "import_cache_size": 0, "cg_pool_size": 0}'
-DOCKER_IMPORT='{"sandbox": "docker", "handler_cache_size": 0, "import_cache_size": 10000000, "cg_pool_size": 0}'
-DOCKER_BOTH='{"sandbox": "docker", "handler_cache_size": 10000000, "import_cache_size": 10000000, "cg_pool_size": 0}'
-
-WORKER_TIMEOUT=60
-
-define RUN_TEST=
-	@echo "Killing worker if running..."
-	-$(KILL_WORKER)
-	@echo
-	@echo "Starting worker..."
-	./bin/admin setconf -cluster=$(TEST_CLUSTER) CONDITION
-	./bin/admin workers -cluster=$(TEST_CLUSTER)
-	@echo
-	@echo "Waiting for worker to initialize..."
-	@for i in $$(seq 1 $(WORKER_TIMEOUT)); \
-	do \
-		[ $$i -gt 1 ] && sleep 2; \
-		./bin/admin status -cluster=$(TEST_CLUSTER) 1>/dev/null && s=0 && break || s=$$?; \
-	done; ([ $$s -eq 0 ] || (echo "Worker failed to initialize after $(WORKER_TIMEOUT)s" && exit 1))
-	@echo "Worker ready. Requesting lambdas..."
-	$(RUN_LAMBDA)/echo -d '{}'
-	@echo
-	$(RUN_LAMBDA)/install -d '{}'
-	@echo
-	$(RUN_LAMBDA)/install2 -d '{}'
-	@echo
-	$(RUN_LAMBDA)/install3 -d '{}'
-	@echo
-	@echo
-endef
 
 GO = $(abspath ./hack/go.sh)
 GO_PATH = hack/go
-WORKER_DIR = $(GO_PATH)/src/github.com/open-lambda/open-lambda/worker
 ADMIN_DIR = $(GO_PATH)/src/github.com/open-lambda/open-lambda/worker/admin
 
 LAMBDA_DIR = $(abspath ./lambda)
@@ -80,21 +37,15 @@ bin/admin: $(WORKER_GO_FILES)
 
 .PHONY: test-all test-sock-all test-docker-all test-cluster
 
-test-all: test-sock-all test-docker-all
+test-all: bin/admin imgs/lambda	
+	python -m unittest discover testing/integration-tests/ -p "*_test.py"
 
-test-sock-all: test-sock-nocache test-sock-handler test-sock-import test-sock-both
+test-sock-all: bin/admin imgs/lambda
+	python testing/integration-tests/sock_test.py
 
-test-docker-all: test-docker-nocache test-docker-handler
+test-docker-all: bin/admin imgs/lambda
+	python testing/integration-tests/docker_test.py
 
-test-cluster: imgs/test-cluster
-
-imgs/test-cluster: 
-	@echo "Starting test cluster..."
-	./bin/admin new -cluster=$(TEST_CLUSTER)
-	./bin/admin setconf -cluster=$(TEST_CLUSTER) $(REGISTRY_DIR)
-	./bin/admin setconf -cluster=$(TEST_CLUSTER) $(STARTUP_PKGS)
-	@echo
-	touch imgs/test-cluster
 
 clean-test:
 	@echo "Killing worker if running..."
@@ -103,30 +54,6 @@ clean-test:
 	@echo "Cleaning up test cluster..."
 	rm -rf $(TEST_CLUSTER) imgs/test-cluster
 	@echo
-
-test-sock-nocache: bin/admin imgs/lambda test-cluster
-	$(subst CONDITION, $(SOCK_NOCACHE), $(RUN_TEST))
-
-test-sock-handler: bin/admin imgs/lambda test-cluster
-	$(subst CONDITION, $(SOCK_HANDLER), $(RUN_TEST))
-
-test-sock-import: bin/admin imgs/lambda test-cluster
-	$(subst CONDITION, $(SOCK_IMPORT), $(RUN_TEST))
-
-test-sock-both: bin/admin imgs/lambda test-cluster
-	$(subst CONDITION, $(SOCK_BOTH), $(RUN_TEST))
-
-test-docker-nocache: bin/admin imgs/lambda test-cluster
-	$(subst CONDITION, $(DOCKER_NOCACHE), $(RUN_TEST))
-
-test-docker-handler: bin/admin imgs/lambda test-cluster
-	$(subst CONDITION, $(DOCKER_HANDLER), $(RUN_TEST))
-
-test-docker-import: bin/admin imgs/lambda test-cluster
-	$(subst CONDITION, $(DOCKER_IMPORT), $(RUN_TEST))
-
-test-docker-both: bin/admin imgs/lambda test-cluster
-	$(subst CONDITION, $(DOCKER_BOTH), $(RUN_TEST))
 
 .PHONY: clean
 clean: clean-test

--- a/testing/integration-tests/cluster_test_utils.py
+++ b/testing/integration-tests/cluster_test_utils.py
@@ -16,7 +16,7 @@ def kill_worker():
     template = """{bin} kill -cluster={cluster_dir}; rm -rf {cluster_dir}/workers/*"""
     data = { 'bin': ADMIN_BIN, 'cluster_dir': TEST_CLUSTER_DIR }
     cmd = template.format(**data)
-    subprocess.call(cmd, shell=True)
+    subprocess.check_output(cmd, shell=True)
 
 def is_worker_active():
     template = """{bin} status -cluster={cluster_dir}"""
@@ -30,13 +30,13 @@ def set_worker_conf(conf):
     template = """{bin} setconf -cluster={cluster_dir} '{conf}'"""
     data = { 'bin': ADMIN_BIN, 'cluster_dir': TEST_CLUSTER_DIR, 'conf': conf }
     cmd = template.format(**data)
-    subprocess.call(cmd, shell=True)
+    subprocess.check_output(cmd, shell=True)
 
 def start_test_worker():
     template = """{bin} workers -cluster={cluster_dir}"""
     data = { 'bin': ADMIN_BIN, 'cluster_dir': TEST_CLUSTER_DIR }
     cmd = template.format(**data)
-    subprocess.call(cmd, shell=True)
+    subprocess.check_output(cmd, shell=True)
 
 def init_worker(conf):
     set_worker_conf(conf)
@@ -48,7 +48,7 @@ def assert_worker_is_ready():
         if is_worker_active():
             return 
     raise IOError('Worker failed to initialize after ' 
-            + str(WORKER_TIMEOUT * 2) + 'seconds.')
+            + str(WORKER_TIMEOUT * 2) + ' seconds.')
 
 def run_lambda(name):
     conn = httplib.HTTPConnection('localhost', 8080, timeout=15)
@@ -56,7 +56,8 @@ def run_lambda(name):
     conn.request('POST', url, '{}')
     response = conn.getresponse()
     if response.status != 200:
-        template = """"Request to run lambda '{name}'failed with status code{status}."""
+        template = 'Request to run lambda "{name}" failed ' 
+        + 'with status code {status}.'
         data = { 'name': name, 'status': response.status }
         msg = template.format(**data)
         raise IOError(msg)

--- a/testing/integration-tests/cluster_test_utils.py
+++ b/testing/integration-tests/cluster_test_utils.py
@@ -1,0 +1,92 @@
+import httplib
+import os
+import subprocess
+import time
+
+def join_paths(base, relative):
+    return os.path.normpath(os.path.join(base, relative))
+
+INTEGRATION_TESTS_DIR = os.path.dirname(os.path.realpath(__file__))
+TEST_CLUSTER_DIR = join_paths(INTEGRATION_TESTS_DIR, '../test-cluster')
+REGISTRY_DIR = join_paths(INTEGRATION_TESTS_DIR, '../registry')
+ADMIN_BIN = join_paths(INTEGRATION_TESTS_DIR, '../../bin/admin')
+WORKER_TIMEOUT = 30
+
+def kill_worker():
+    template = """{bin} kill -cluster={cluster_dir}; rm -rf {cluster_dir}/workers/*"""
+    data = { 'bin': ADMIN_BIN, 'cluster_dir': TEST_CLUSTER_DIR }
+    cmd = template.format(**data)
+    subprocess.call(cmd, shell=True)
+
+def is_worker_active():
+    template = """{bin} status -cluster={cluster_dir}"""
+    data = { 'bin': ADMIN_BIN, 'cluster_dir': TEST_CLUSTER_DIR }
+    cmd = template.format(**data)
+    devnull = open(os.devnull, 'w')
+    exit_code = subprocess.call(cmd, shell=True, stdout=devnull)
+    return exit_code == 0
+
+def set_worker_conf(conf):
+    template = """{bin} setconf -cluster={cluster_dir} '{conf}'"""
+    data = { 'bin': ADMIN_BIN, 'cluster_dir': TEST_CLUSTER_DIR, 'conf': conf }
+    cmd = template.format(**data)
+    subprocess.call(cmd, shell=True)
+
+def start_test_worker():
+    template = """{bin} workers -cluster={cluster_dir}"""
+    data = { 'bin': ADMIN_BIN, 'cluster_dir': TEST_CLUSTER_DIR }
+    cmd = template.format(**data)
+    subprocess.call(cmd, shell=True)
+
+def init_worker(conf):
+    set_worker_conf(conf)
+    start_test_worker()
+
+def assert_worker_is_ready():
+    for i in range(WORKER_TIMEOUT):
+        time.sleep(2)
+        if is_worker_active():
+            return 
+    raise IOError('Worker failed to initialize after ' 
+            + str(WORKER_TIMEOUT * 2) + 'seconds.')
+
+def run_lambda(name):
+    conn = httplib.HTTPConnection('localhost', 8080, timeout=15)
+    url = '/runLambda/' + name
+    conn.request('POST', url, '{}')
+    response = conn.getresponse()
+    if response.status != 200:
+        template = """"Request to run lambda '{name}'failed with status code{status}."""
+        data = { 'name': name, 'status': response.status }
+        msg = template.format(**data)
+        raise IOError(msg)
+
+def create_test_cluster():
+    template = """{bin} new -cluster={cluster_dir}"""
+    data = { 'bin': ADMIN_BIN, 'cluster_dir': TEST_CLUSTER_DIR }
+    cmd = template.format(**data)
+    subprocess.call(cmd, shell=True)
+
+def start_test_cluster(): 
+    print("Starting test cluster...")
+    create_test_cluster()
+
+    STARTUP_PKGS_CONF ='{"startup_pkgs": ["parso", "jedi", "urllib3", "idna", "chardet", "certifi", "requests", "simplejson"]}'
+    REGISTRY_DIR_CONF ='{"registry_dir": "' + REGISTRY_DIR + '"}'
+    set_worker_conf(STARTUP_PKGS_CONF)
+    set_worker_conf(REGISTRY_DIR_CONF)
+
+def run_cluster_test_with_conf(conf):
+    print('Killing worker if running...')
+    kill_worker()
+    print('Starting worker...')
+    init_worker(conf)
+    print('Waiting for worker to initialize...')
+    assert_worker_is_ready()
+    print('Worker ready. Requesting lambdas...')
+    run_lambda('echo')
+    run_lambda('install')
+    run_lambda('install2')
+    run_lambda('install3')
+
+

--- a/testing/integration-tests/docker_test.py
+++ b/testing/integration-tests/docker_test.py
@@ -1,0 +1,31 @@
+import json
+import unittest
+from cluster_test_utils import start_test_cluster, run_cluster_test_with_conf 
+
+
+class DockerTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        start_test_cluster()
+
+    def test_with_no_cache(self):
+        conf = json.dumps({
+            'sandbox': 'docker', 
+            'handler_cache_size': 0, 
+            'import_cache_size': 0, 
+            'cg_pool_size': 0
+        })        
+        run_cluster_test_with_conf(conf)
+
+    def test_with_handler_cache(self):
+        conf = json.dumps({
+            'sandbox': 'docker', 
+            'handler_cache_size': 10000000, 
+            'import_cache_size': 0, 
+            'cg_pool_size': 0
+        })        
+        run_cluster_test_with_conf(conf)
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/testing/integration-tests/sock_test.py
+++ b/testing/integration-tests/sock_test.py
@@ -1,0 +1,49 @@
+import json
+import unittest
+from cluster_test_utils import start_test_cluster, run_cluster_test_with_conf 
+
+
+class SockTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        start_test_cluster()
+
+    def test_with_no_cache(self):
+        conf = json.dumps({
+            'sandbox': 'sock', 
+            'handler_cache_size': 0, 
+            'import_cache_size': 0, 
+            'cg_pool_size': 10
+        })        
+        run_cluster_test_with_conf(conf)
+
+    def test_with_handle_cache(self):
+        conf = json.dumps({
+            'sandbox': 'sock', 
+            'handler_cache_size': 10000000, 
+            'import_cache_size': 0, 
+            'cg_pool_size': 10
+        })        
+        run_cluster_test_with_conf(conf)
+
+    def test_with_import_cache(self):
+        conf = json.dumps({
+            'sandbox': 'sock', 
+            'handler_cache_size': 0, 
+            'import_cache_size': 10000000, 
+            'cg_pool_size': 10
+        })        
+        run_cluster_test_with_conf(conf)
+
+    def test_with_both_caches(self):
+        conf = json.dumps({
+            'sandbox': 'sock', 
+            'handler_cache_size': 10000000, 
+            'import_cache_size': 10000000, 
+            'cg_pool_size': 10
+        })        
+        run_cluster_test_with_conf(conf)
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Hi, I've been playing around with open lambda for a school project and it's pretty cool. Great job guys! 

Running tests with a makefile seemed very brittle to me so I created a new folder `testing/integration-tests` in which I implemented all the integration tests in a real test suite using Python's built in `unittest`. 
There are probably better testing frameworks like `pytest` but I decided to use `unittest` to avoid adding extra dependencies to the project. If you guys prefer a different framework, the migration would be very quickly since the test cases have very little code specific to `unittest`. The advantages of this approach over the makefile are:

- All tests will always run, even if the first ones fail.
- Better UX when you run test since at the end you get a little report with results.
- No more shell hackery like `1 > dev/null`, so tests are more readable and mantainable.
- It is possible to run some clean up code whenever tests fail (Not implemented yet)


I decided to keep the `make test-all` interface to run the tests so that the change is seamless. 
I haven't implemented all the existent docker tests, only the ones  that actually run wth `make test-docker-all`. The rest can be added very quickly.

Here is a screenshout with the tests running on my VM:

![screenshot from 2018-05-20 20-02-45](https://user-images.githubusercontent.com/5729175/40286061-3ffb1334-5c69-11e8-8e5d-8b038208f881.png)
