### PR TITLE
Use defer to unlock mutexes from Install method of installManager.go

### DIFF
--- a/worker/pip-manager/installManager.go
+++ b/worker/pip-manager/installManager.go
@@ -56,26 +56,24 @@ func InitInstallManager(opts *config.Config) (*Installer, error) {
 func (i *Installer) Install(pkgs []string) error {
 	for _, pkg := range pkgs {
 		i.mutex.Lock()
+		defer i.mutex.Unlock()
 		pkgState, ok := i.pkgStates[pkg]
 		if !ok {
 			rwMutex := &sync.RWMutex{}
 			rwMutex.Lock()
+			defer rwMutex.Unlock()
 			i.pkgStates[pkg] = &PackageState{rwMutex}
-			i.mutex.Unlock()
 
 			cmd := exec.Command(i.cmd, append(i.args, pkg)...)
 			if err := cmd.Run(); err != nil {
 				delete(i.pkgStates, pkg)
-				i.mutex.Unlock()
-				return fmt.Errorf("failed to install package '%s' :: %v", pkg, err)
+				return fmt.Errorf("failed to install package '%s' :: error %v :: cmd %v", pkg, err, cmd)
 			}
-			rwMutex.Unlock()
 		} else {
 			// The ordering here will have to change when we implement package
 			// eviction - the package could be evicted after dropping the global
 			// lock. We will also have to release reader locks on eviction of
 			// handlers/cache entries.
-			i.mutex.Unlock()
 			pkgState.mutex.RLock()
 		}
 	}


### PR DESCRIPTION
When cmd returns an error i.mutex.Unlock() is called twice making the function to panic. After panicking the lambda node returns 502 http error instead of 500.