### PR TITLE
Add i.mutex.Lock() before delete(i.pkgStates, pkg) to avoid calling i…

### DIFF
--- a/worker/pip-manager/installManager.go
+++ b/worker/pip-manager/installManager.go
@@ -60,16 +60,16 @@ func (i *Installer) Install(pkgs []string) error {
 		if !ok {
 			rwMutex := &sync.RWMutex{}
 			rwMutex.Lock()
+			defer rwMutex.Unlock()
 			i.pkgStates[pkg] = &PackageState{rwMutex}
 			i.mutex.Unlock()
-
 			cmd := exec.Command(i.cmd, append(i.args, pkg)...)
 			if err := cmd.Run(); err != nil {
+				i.mutex.Lock()
 				delete(i.pkgStates, pkg)
 				i.mutex.Unlock()
-				return fmt.Errorf("failed to install package '%s' :: %v", pkg, err)
+				return fmt.Errorf("failed to install package '%s' :: %v :: %v", pkg, err, cmd)
 			}
-			rwMutex.Unlock()
 		} else {
 			// The ordering here will have to change when we implement package
 			// eviction - the package could be evicted after dropping the global

--- a/worker/pip-manager/installManager.go
+++ b/worker/pip-manager/installManager.go
@@ -76,8 +76,8 @@ func (i *Installer) Install(pkgs []string) error {
 			// lock. We will also have to release reader locks on eviction of
 			// handlers/cache entries.
 			i.mutex.Unlock()
-			pkgState.mutex.RLock()
 		}
+		pkgState.mutex.RLock()
 	}
 
 	return nil


### PR DESCRIPTION
Add i.mutex.Lock() before delete(i.pkgStates, pkg) to avoid calling i.mutex.Unlock() twice when install package cmd returns an error.