### PR TITLE
[Code Only] Work of Lambda Team in S19 CS838 Edge Computing Lab

### DIFF
--- a/worker/config/config.go
+++ b/worker/config/config.go
@@ -46,6 +46,13 @@ type Config struct {
 	Handler_cache_size int `json:"handler_cache_size"` //kb
 	Import_cache_size  int `json:"import_cache_size"`  //kb
 
+	// mem usage limits for creating sandboxes
+	Create_sandbox_soft_limit float64 `json:"create_sandbox_soft_limit"` //mem usage percentage, from 0.0 (0%) to 1.0 (100%)
+	Create_sandbox_hard_limit float64 `json:"create_sandbox_hard_limit"` //mem usage percentage, from 0.0 (0%) to 1.0 (100%)
+
+	// max number of sandboxes being created at the same time (after hit soft limit)
+	Max_num_sandbox_creating int `json:"max_num_sandbox_creating"`
+
 	// sandbox options
 	// worker directory, which contains handler code, pid file, logs, etc.
 	Worker_dir string `json:"worker_dir"`
@@ -125,6 +132,20 @@ func (c *Config) Defaults() error {
 
 	if c.Registry_dir == "" {
 		return fmt.Errorf("must specify local registry directory")
+	}
+
+	// mem usage limits for creating sandboxes
+	if c.Create_sandbox_soft_limit == 0.0 {
+		c.Create_sandbox_soft_limit = 0.5
+	} 
+
+	if c.Create_sandbox_hard_limit == 0.0 {
+		c.Create_sandbox_hard_limit = 0.9
+	} 
+
+	// max number of sandboxes being created at the same time (after hit soft limit)
+	if c.Max_num_sandbox_creating == 0 {
+		c.Max_num_sandbox_creating = 4
 	}
 
 	if !path.IsAbs(c.Registry_dir) {

--- a/worker/config/config.go
+++ b/worker/config/config.go
@@ -46,12 +46,11 @@ type Config struct {
 	Handler_cache_size int `json:"handler_cache_size"` //kb
 	Import_cache_size  int `json:"import_cache_size"`  //kb
 
-	// mem usage limits for creating sandboxes
-	Create_sandbox_soft_limit float64 `json:"create_sandbox_soft_limit"` //mem usage percentage, from 0.0 (0%) to 1.0 (100%)
-	Create_sandbox_hard_limit float64 `json:"create_sandbox_hard_limit"` //mem usage percentage, from 0.0 (0%) to 1.0 (100%)
+	// average memory usage for each handler
+	Average_handler_memory_usage int `json:"average_handler_memory_usage"` //kb
 
-	// max number of sandboxes being created at the same time (after hit soft limit)
-	Max_num_sandbox_creating int `json:"max_num_sandbox_creating"`
+	// mem usage limit for creating sandboxes
+	Create_sandbox_hard_limit int `json:"create_sandbox_hard_limit"` //kb
 
 	// sandbox options
 	// worker directory, which contains handler code, pid file, logs, etc.
@@ -132,20 +131,6 @@ func (c *Config) Defaults() error {
 
 	if c.Registry_dir == "" {
 		return fmt.Errorf("must specify local registry directory")
-	}
-
-	// mem usage limits for creating sandboxes
-	if c.Create_sandbox_soft_limit == 0.0 {
-		c.Create_sandbox_soft_limit = 0.8
-	} 
-
-	if c.Create_sandbox_hard_limit == 0.0 {
-		c.Create_sandbox_hard_limit = 0.9
-	} 
-
-	// max number of sandboxes being created at the same time (after hit soft limit)
-	if c.Max_num_sandbox_creating == 0 {
-		c.Max_num_sandbox_creating = 4
 	}
 
 	if !path.IsAbs(c.Registry_dir) {

--- a/worker/config/config.go
+++ b/worker/config/config.go
@@ -46,11 +46,14 @@ type Config struct {
 	Handler_cache_size int `json:"handler_cache_size"` //kb
 	Import_cache_size  int `json:"import_cache_size"`  //kb
 
-	// average memory usage for each handler
-	Average_handler_memory_usage int `json:"average_handler_memory_usage"` //kb
-
 	// mem usage limit for creating sandboxes
-	Create_sandbox_hard_limit int `json:"create_sandbox_hard_limit"` //kb
+	Sandbox_create_hard_limit int `json:"sandbox_create_hard_limit"` //kb
+
+	// size limit of the queue containing handlers waiting to create sandbox
+	Sandbox_create_queue_size int `json:"sanbox_create_queue_size"`
+
+	// time interval to update average handler memory usage
+	Handler_usage_update_interval int `json:"handler_usage_update_interval"` // seconds
 
 	// sandbox options
 	// worker directory, which contains handler code, pid file, logs, etc.
@@ -131,6 +134,14 @@ func (c *Config) Defaults() error {
 
 	if c.Registry_dir == "" {
 		return fmt.Errorf("must specify local registry directory")
+	}
+
+	if c.Sandbox_create_queue_size == 0 {
+		c.Sandbox_create_queue_size = 100
+	}
+
+	if c.Handler_usage_update_interval == 0 {
+		c.Handler_usage_update_interval = 10
 	}
 
 	if !path.IsAbs(c.Registry_dir) {

--- a/worker/config/config.go
+++ b/worker/config/config.go
@@ -136,7 +136,7 @@ func (c *Config) Defaults() error {
 
 	// mem usage limits for creating sandboxes
 	if c.Create_sandbox_soft_limit == 0.0 {
-		c.Create_sandbox_soft_limit = 0.5
+		c.Create_sandbox_soft_limit = 0.8
 	} 
 
 	if c.Create_sandbox_hard_limit == 0.0 {

--- a/worker/handler/handler.go
+++ b/worker/handler/handler.go
@@ -185,6 +185,9 @@ func (hms *HandlerManagerSet) updateAvgHandlerMemUsage(updateInterval int) {
 	}
 }
 
+// Seperate goroutine for scheduling requests of creating sandboxes. Periodically check memory usage
+// against hard limit, resume a request when less.
+
 func (hms *HandlerManagerSet) scheduleSbCreatingReqs() {
 	for {
 		hms.sbCreatingLock.Lock()

--- a/worker/handler/handler.go
+++ b/worker/handler/handler.go
@@ -147,8 +147,7 @@ var memLastUpdateTime time.Time = time.Now()
 func getMemUsage() int {
 	if (time.Since(memLastUpdateTime)) > time.Second {
 		v, _ := mem.VirtualMemory()
-		total, free := int(v.Total), int(v.Free)
-		memUsage = total - free
+		memUsage = int(v.Used)
 		memLastUpdateTime = time.Now()
 	}
 	return memUsage

--- a/worker/handler/handler.go
+++ b/worker/handler/handler.go
@@ -361,16 +361,14 @@ func (h *Handler) RunStart() (ch *sb.Channel, err error) {
 	// create sandbox if needed
 	if h.sandbox == nil {
 		// if estimated mem usage exceeds the hard limit, the handler would queue itself
-        hms.sbCreatingLock.Lock()
-        for hms.sbHardLimit != 0 && (getMemUsage() + (hms.numSbCreating + 1) * hms.avgHandlerMemUsage > hms.sbHardLimit) {
-            hms.sbCreatingLock.Unlock()
+		if hms.sbHardLimit != 0 {
 			if h.sbCreatingChan == nil {
 				h.sbCreatingChan = make(chan bool, 1)
 			}
 			hms.sbCreatingQueue <- h
 			<-h.sbCreatingChan // waiting for wake-up signal
-            hms.sbCreatingLock.Lock()
 		}
+		hms.sbCreatingLock.Lock()
 		hms.numSbCreating += 1
 		hms.sbCreatingLock.Unlock()
 


### PR DESCRIPTION
This is the code part of PR https://github.com/open-lambda/open-lambda/pull/53.

> In this PR, we added the following two features for workers:
> 
> 1. Enable requests of the same lambda to reuse a handler.
>    
>    * To accomplish this, we moved the code that adds a new handler to the `HandlerManagerSet .HandlerManager.handlers` list.
> 2. Added request queuing mechanism (mem usage hard limit) for workers.
>    
>    * Added a utility function to get the current machine memory usage, making use of [shirou/gopsutil](https://github.com/shirou/gopsutil)
>    * Added both a soft limit (`Config.Create_sandbox_soft_limit `/`HandlerManagerSet.sbSoftLimit`) and a hard limit (`Config.Create_sandbox_hard_limit `/`HandlerManagerSet.sbHardLimit`) for memory usage when creating new sandboxes.
>      
>      * When memory usage exceeds the soft limit, at most `Config.Max_num_sandbox_creating `/`HandlerManagerSet.maxNumSbCreating ` sandboxes can be being created at the same time.
>      * When memory usage exceeds the hard limit, requests creating new sandboxes will be blocked, until memory usage decreases.