### PR TITLE
Add swappiness option in config.go

### DIFF
--- a/src/common/config.go
+++ b/src/common/config.go
@@ -114,7 +114,7 @@ func LoadDefaults(olPath string) error {
 		Limits: LimitsConfig{
 			Procs:            10,
 			Mem_mb:           50,
-			Swappiness:	  0,
+			Swappiness:       0,
 			Installer_mem_mb: 200,
 		},
 	}

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -68,6 +68,9 @@ type LimitsConfig struct {
 	// always set a lower limit for itself.
 	Mem_mb int `json:"mem_mb"`
 
+	// how aggresively will the mem of the Sandbox be swapped?
+	Swappiness int `json:"swappiness"`
+
 	// how much memory do we use for an admin lambda that is used
 	// for pip installs?
 	Installer_mem_mb int `json:"installer_mem_mb"`
@@ -111,6 +114,7 @@ func LoadDefaults(olPath string) error {
 		Limits: LimitsConfig{
 			Procs:            10,
 			Mem_mb:           50,
+			Swappiness:	  0,
 			Installer_mem_mb: 200,
 		},
 	}

--- a/src/sandbox/cgroups.go
+++ b/src/sandbox/cgroups.go
@@ -142,6 +142,7 @@ Loop:
 		default:
 			cg = pool.NewCgroup()
 			cg.WriteInt("pids", "pids.max", int64(common.Conf.Limits.Procs))
+			cg.WriteInt("memory", "memory.swappiness", int64(common.Conf.Limits.Swappiness))
 		}
 
 		// add cgroup to ready queue


### PR DESCRIPTION
This addresses #86.

Setting default swappiness of Sandboxes as 0 prevents the kernel from swapping the mem of the sandboxes, making the mem limit enforceable, i.e. Sandbox will get killed once its mem usage exceeds the limit set.