### PR TITLE
Build ol library inside the container to avoid host compatibility concerns

### DIFF
--- a/lambda/Dockerfile
+++ b/lambda/Dockerfile
@@ -8,7 +8,11 @@ RUN pip3 install virtualenv requests tornado==4.5.3
 
 # for SOCK container engine
 COPY sock2.py /
-COPY ol.so /
+
+# Build python module in container to avoid depending on the host
+COPY ol.c /
+COPY setup.py /
+RUN cd / && python3 setup.py build_ext --inplace && mv ol.*.so /ol.so
 
 # for Docker container engine
 COPY server.py /

--- a/lambda/Makefile
+++ b/lambda/Makefile
@@ -1,15 +1,11 @@
 .PHONY: all
 
-all: ol.so spin
-
-ol.so: setup.py ol.c
-	python3 setup.py build_ext --inplace
-	mv ol.*.so ./ol.so
+all: spin
 
 spin: spin.c
-	gcc -O2 -o spin spin.c
+	gcc -O2 --static -o spin spin.c
 
 .PHONY: clean
 
 clean:
-	rm -rf spin ol.so
+	rm -rf spin


### PR DESCRIPTION
I know the official way to use OpenLambda is on the development VM, but I was trying to run it on Arch Linux anyway. The problem I ran into was that ol.so was built on the host and linked against the host's version of libpython. On the standard build VM this is fine because the container and the host are running the same version of everything, but on different hosts, those dependencies might differ. The solution is to build everything that runs in the container in the container itself to ensure compatibility. I also changed spin.c to link statically for good measure (it wasn't causing me problems, but it might conceivably run into a similar issue to ol.so in the future).

Anyway, I figured I'd PR my fix in case it helped anyone else.