### PR TITLE
Convert Latency methods to a pointer receiver

### DIFF
--- a/src/common/stats.go
+++ b/src/common/stats.go
@@ -99,15 +99,15 @@ type Latency struct {
 }
 
 // record start time
-func T0(name string) Latency {
-	return Latency{
+func T0(name string) *Latency {
+	return &Latency{
 		name: name,
 		t0:   time.Now(),
 	}
 }
 
 // measure latency to end time, and record it
-func (l Latency) T1() {
+func (l *Latency) T1() {
 	l.Milliseconds = int64(time.Now().Sub(l.t0)) / 1000000
 	if l.Milliseconds < 0 {
 		panic("negative latency")
@@ -123,7 +123,7 @@ func (l Latency) T1() {
 }
 
 // start measuring a sub latency
-func (l Latency) T0(name string) Latency {
+func (l *Latency) T0(name string) *Latency {
 	return T0(l.name + "/" + name)
 }
 


### PR DESCRIPTION
Previously l.Milliseconds would always be 0 becaust lat.T1() worked on a copy of lat. One implication of this is that the autoscaling algorithms would never scale the number of containers (since the algorithm was based on estimated outstanding work, which was always 0).