### PR TITLE
use cgroup.kill to stop all processes

### DIFF
--- a/scripts/test.py
+++ b/scripts/test.py
@@ -227,7 +227,7 @@ def run_tests():
     max_mem_alloc()
 
     # numpy pip install needs a larger mem cap
-    with TestConfContext(mem_pool_mb=1000):
+    with TestConfContext(mem_pool_mb=1000, trace={"cgroups": True}):
         numpy_test()
 
     # make sure code updates get pulled within the cache time

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -263,7 +263,13 @@ def main():
     setup_config(args.ol_dir)
     prepare_open_lambda(args.ol_dir)
 
-    with TestConfContext(registry=os.path.abspath(args.registry)):
+    trace_config = {
+        "cgroups": True,
+        "memory": True,
+        "evictor": True,
+        "package": True,
+    }
+    with TestConfContext(registry=os.path.abspath(args.registry), trace=trace_config):
         if args.worker_type == 'docker':
             set_worker_type(DockerWorker)
         elif args.worker_type == 'sock':

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -160,6 +160,12 @@ func LoadDefaults(olPath string) error {
 			Import_cache:        true,
 			Downsize_paused_mem: true,
 		},
+		Trace: TraceConfig{
+			Cgroups: false,
+			Memory: false,
+			Evictor: false,
+			Package: false,
+		},
 		Storage: StorageConfig{
 			Root:    "private",
 			Scratch: "",

--- a/src/main.go
+++ b/src/main.go
@@ -382,7 +382,7 @@ func kill(ctx *cli.Context) error {
 	for i := 0; i < 300; i++ {
 		err := p.Signal(syscall.Signal(0))
 		if err != nil {
-			fmt.Printf("OL worker process stopped successfully")
+			fmt.Printf("OL worker process stopped successfully\n")
 			return nil // good, process must have stopped
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/src/sandbox/sock.go
+++ b/src/sandbox/sock.go
@@ -311,10 +311,12 @@ func (container *SOCKContainer) decCgRefCount() {
 			container.containerProxy.Wait()
 		}
 
-		t := common.T0("Destroy()/kill-procs")
+		t := common.T0("Destroy()/cleanup-cgroup")
 		if container.cg != nil {
-			pids := container.cg.KillAllProcs()
-			container.printf("killed PIDs %v in CG\n", pids)
+			container.cg.KillAllProcs()
+			container.printf("killed PIDs in CG\n")
+			container.cg.Release()
+			container.pool.mem.adjustAvailableMB(container.cg.getMemLimitMB())
 		}
 		t.T1()
 
@@ -330,9 +332,6 @@ func (container *SOCKContainer) decCgRefCount() {
 			container.printf("remove root dir %s failed :: %v\n", container.containerRootDir, err)
 		}
 		t.T1()
-
-		container.cg.Release()
-		container.pool.mem.adjustAvailableMB(container.cg.getMemLimitMB())
 
 		if container.parent != nil {
 			container.parent.childExit(container)


### PR DESCRIPTION
Now that we're on v2 of cgroups, we can replace the nasty KillAllProcs with a one liner that writes 1 to cgroup.kill (https://lwn.net/Articles/855924/).

Playing around with this, I've noticed a couple things:
1. it works even if the cgroup processes are paused (this was a big pain before because we had to unpause them to kill them)
2. you can't always rmdir the cgroup after killing it, so I added retry, up to 50ms.  It looks like it is often taking 5-15ms for rmdir to succeed, so I'm not sure 50ms is long enough (or if there's a way to use events rather than polling).