### PR TITLE
fix package installation & import

### DIFF
--- a/src/worker/lambda/lambdaFunction.go
+++ b/src/worker/lambda/lambdaFunction.go
@@ -88,6 +88,7 @@ func parseMeta(codeDir string) (meta *sandbox.SandboxMeta, err error) {
 		line := strings.ReplaceAll(scnr.Text(), " ", "")
 		pkg := strings.Split(line, "#")[0]
 		if pkg != "" {
+			pkg = strings.Split(pkg, ";")[0] // ignore conditional dependencies
 			pkg = packages.NormalizePkg(pkg)
 			meta.Installs = append(meta.Installs, pkg)
 		}

--- a/src/worker/lambda/zygote/importCache.go
+++ b/src/worker/lambda/zygote/importCache.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -285,19 +286,29 @@ func (cache *ImportCache) createSandboxInNode(node *ImportCacheNode, rt_type com
 	if node.codeDir == "" {
 		codeDir := cache.codeDirs.Make("import-cache")
 		// TODO: clean this up upon failure
-
-		installs, err := cache.pkgPuller.InstallRecursive(node.Packages)
-		if err != nil {
-			return err
+		// if all pkgs required by lambda are guaranteed to be installed, then no need to call getPkg(),
+		// but sometimes a zygote is created without requests, e.g. warm up the tree, then getPkg() is needed
+		installs := []string{}
+		for _, name := range node.AllPackages() {
+			_, err := cache.pkgPuller.GetPkg(name)
+			if err != nil {
+				return fmt.Errorf("ImportCache.go: could not get package %s: %v", name, err)
+			}
+			installs = append(installs, name)
 		}
 
 		topLevelMods := []string{}
 		for _, name := range node.Packages {
-			pkg, err := cache.pkgPuller.GetPkg(name)
+			pkgPath := filepath.Join(common.Conf.SOCK_base_path, "packages", name, "files")
+			moduleInfos, err := packages.IterModules(pkgPath)
 			if err != nil {
 				return err
 			}
-			topLevelMods = append(topLevelMods, pkg.Meta.TopLevel...)
+			modulesNames := []string{}
+			for _, moduleInfo := range moduleInfos {
+				modulesNames = append(modulesNames, moduleInfo.Name)
+			}
+			topLevelMods = append(topLevelMods, modulesNames...)
 		}
 
 		node.codeDir = codeDir

--- a/src/worker/sandbox/sockPool.go
+++ b/src/worker/sandbox/sockPool.go
@@ -1,14 +1,15 @@
 package sandbox
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net"
+	"net/http"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
-	"net"
-	"net/http"
 	"time"
 
 	"github.com/open-lambda/open-lambda/ol/common"
@@ -62,6 +63,26 @@ func sbStr(sb Sandbox) string {
 		return "<nil>"
 	}
 	return fmt.Sprintf("<SB %s>", sb.ID())
+}
+
+func importLines(modules []string) (string, error) {
+	if len(modules) == 0 {
+		return "", nil
+	}
+	modulesStr, err := json.Marshal(modules)
+	if err != nil {
+		fmt.Println("Error marshalling JSON:", err)
+		return "", nil
+	}
+	code := fmt.Sprintf(`
+os.environ['OPENBLAS_NUM_THREADS'] = '2'
+for mod in %s:
+	try:
+		importlib.import_module(mod)
+	except Exception as e:
+		pass
+    `, modulesStr)
+	return code, nil
 }
 
 func (pool *SOCKPool) Create(parent Sandbox, isLeaf bool, codeDir, scratchDir string, meta *SandboxMeta, rtType common.RuntimeType) (sb Sandbox, err error) {
@@ -125,21 +146,18 @@ func (pool *SOCKPool) Create(parent Sandbox, isLeaf bool, codeDir, scratchDir st
 	if rtType == common.RT_PYTHON {
 		// add installed packages to the path, and import the modules we'll need
 		var pyCode []string
-
+		// by this step, all packages are guaranteed to be installed in pullHandlerIfStale()
 		for _, pkg := range meta.Installs {
 			path := "'/packages/" + pkg + "/files'"
-			pyCode = append(pyCode, "if os.path.exists("+path+"):")
-			pyCode = append(pyCode, "	if not "+path+" in sys.path:")
-			pyCode = append(pyCode, "		sys.path.insert(0, "+path+")")
+			pyCode = append(pyCode, "if not "+path+" in sys.path:")
+			pyCode = append(pyCode, "    sys.path.insert(0, "+path+")")
 		}
 
-		// we need handle any possible error while importing a module
-		for _, mod := range meta.Imports {
-			pyCode = append(pyCode, "try:")
-			pyCode = append(pyCode, "	import "+mod)
-			pyCode = append(pyCode, "except Exception as e:")
-			pyCode = append(pyCode, "	print('bootstrap.py error:', e)")
+		lines, err := importLines(meta.Imports)
+		if err != nil {
+			log.Printf("Error generating import lines: %v", err)
 		}
+		pyCode = append(pyCode, lines)
 
 		// handler or Zygote?
 		if isLeaf {
@@ -192,7 +210,7 @@ func (pool *SOCKPool) Create(parent Sandbox, isLeaf bool, codeDir, scratchDir st
 
 	cSock.client = &http.Client{
 		Transport: &http.Transport{Dial: dial},
-		Timeout: time.Second * time.Duration(common.Conf.Limits.Max_runtime_default),
+		Timeout:   time.Second * time.Duration(common.Conf.Limits.Max_runtime_default),
 	}
 
 	// event handling


### PR DESCRIPTION
  When package is already installed in previous run, PackagePuller is only created to fetch top-level modules and dependency.
  In this situation, OL doesn't have to start a PackagePuller container. Since all the dependencies are specified in Zygote tree, and I implement a go function to scan the top-level modules.