### PR TITLE
Enable basic go linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
          python-version: '3.12'
     - name: Install pylint
       run: pip3 install pylint==2.15.0
+    - name: Install revive (go linter)
+      run: go install github.com/mgechev/revive@latest
     - name: Install cross
       run: cargo install cross
     - name: Build OpenLambda

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ lint-functions:
 lint-wasm-worker:
 	cd wasm-worker && cargo clippy
 
-lint: lint-wasm-worker lint-functions lint-python #lint-go
+lint: lint-wasm-worker lint-functions lint-python lint-go
 
 clean:
 	rm -f ol imgs/ol-min imgs/ol-wasm

--- a/golint.toml
+++ b/golint.toml
@@ -12,6 +12,20 @@ enableAllRules = true
 [rule.unhandled-error]
     Disabled = true
 
+#TODO use uniform casing everywhere
+[rule.var-naming]
+    Disabled = true
+
+[rule.import-shadowing]
+    Disabled = true
+[rule.unused-parameter]
+    Disabled = true
+[rule.unused-receiver]
+    Disabled = true
+[rule.receiver-naming]
+    Disabled = true
+[rule.error-strings]
+    Disabled = true
 [rule.exported]
     Disabled = true
 [rule.early-return]
@@ -32,10 +46,12 @@ enableAllRules = true
     Disabled = true
 [rule.increment-decrement]
     Disabled = true
+[rule.flag-parameter]
+    Disabled = true
 
 [rule.argument-limit]
     Arguments = [7]
 [rule.cyclomatic]
-    Arguments = [10]
+    Arguments = [20]
 [rule.function-result-limit]
     Arguments = [3]

--- a/golint.toml
+++ b/golint.toml
@@ -16,6 +16,16 @@ enableAllRules = true
 [rule.var-naming]
     Disabled = true
 
+[rule.defer]
+    Disabled = true
+[rule.empty-block]
+    Disabled = true
+[ruile.var-declaration]
+    Disabled = true
+[rule.confusing-results]
+    Disabled = true
+[rule.call-to-gc]
+    Disabled = true
 [rule.import-shadowing]
     Disabled = true
 [rule.unused-parameter]
@@ -51,7 +61,9 @@ enableAllRules = true
 
 [rule.argument-limit]
     Arguments = [7]
+
+# TODO reduce to 10 or so
 [rule.cyclomatic]
-    Arguments = [20]
+    Arguments = [35]
 [rule.function-result-limit]
     Arguments = [3]

--- a/src/boss/boss.go
+++ b/src/boss/boss.go
@@ -42,8 +42,6 @@ func (b *Boss) BossStatus(w http.ResponseWriter, r *http.Request) {
 	} else {
 		w.Write(b)
 	}
-
-
 }
 
 func (b *Boss) Close(w http.ResponseWriter, r *http.Request) {

--- a/src/boss/cloudvm/gcp.go
+++ b/src/boss/cloudvm/gcp.go
@@ -144,7 +144,7 @@ func NewGcpClient(service_account_json string) (*GcpClient, error) {
 	return client, nil
 }
 
-func (c *GcpClient) RunComandWorker(VMName string, command string) error {
+func (c *GcpClient) RunComandWorker(vmName string, command string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		panic(err)
@@ -160,7 +160,7 @@ func (c *GcpClient) RunComandWorker(VMName string, command string) error {
 		panic(err)
 	}
 
-	ip, ok := lookup[VMName]
+	ip, ok := lookup[vmName]
 	if !ok {
 		fmt.Println(lookup)
 		panic(fmt.Errorf("could not find IP for instance"))
@@ -485,15 +485,15 @@ func (c *GcpClient) GcpSnapshot(disk string, snapshot_name string) (map[string]a
 	return c.post(url, payload)
 }
 
-func (c *GcpClient) LaunchGcp(SnapshotName string, VMName string) (map[string]any, error) {
+func (c *GcpClient) LaunchGcp(snapshotName string, vmName string) (map[string]any, error) {
 	args := GcpLaunchVmArgs{
 		ServiceAccountEmail: c.service_account["client_email"].(string),
 		Project:             c.service_account["project_id"].(string),
 		Region:              c.service_account["region"].(string),
 		Zone:                c.service_account["zone"].(string),
-		InstanceName:        VMName,
+		InstanceName:        vmName,
 		//SourceImage: "projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20220204",
-		SnapshotName:        SnapshotName,
+		SnapshotName:        snapshotName,
 		DiskSizeGb:          GcpConf.DiskSizeGb,
 		MachineType:         GcpConf.MachineType,
 	}
@@ -510,33 +510,33 @@ func (c *GcpClient) LaunchGcp(SnapshotName string, VMName string) (map[string]an
 	return c.post(url, payload)
 }
 
-func (c *GcpClient) startGcpInstance(VMName string) (map[string]any, error) { //start existing instance
+func (c *GcpClient) startGcpInstance(vmName string) (map[string]any, error) { //start existing instance
 	url := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/instances/%s/start",
 		c.service_account["project_id"].(string),
 		c.service_account["zone"].(string),
-		VMName)
+		vmName)
 
 	var payload bytes.Buffer
 
 	return c.post(url, payload)
 }
 
-func (c *GcpClient) stopGcpInstance(VMName string) (map[string]any, error) {
+func (c *GcpClient) stopGcpInstance(vmName string) (map[string]any, error) {
 	url := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/instances/%s/stop",
 		c.service_account["project_id"].(string),
 		c.service_account["zone"].(string),
-		VMName)
+		vmName)
 
 	var payload bytes.Buffer
 
 	return c.post(url, payload)
 }
 
-func (c *GcpClient) deleteGcpInstance(VMName string) (map[string]any, error) {
+func (c *GcpClient) deleteGcpInstance(vmName string) (map[string]any, error) {
 	url := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/instances/%s",
 		c.service_account["project_id"].(string),
 		c.service_account["zone"].(string),
-		VMName)
+		vmName)
 
 	return c.delete(url)
 }

--- a/src/boss/cloudvm/worker.go
+++ b/src/boss/cloudvm/worker.go
@@ -55,9 +55,11 @@ func NewWorkerPool(platform string, worker_cap int) (*WorkerPool, error) {
 	go func() {
 		for true {
 			time.Sleep(time.Second)
-			var avgLatency int64 = 0
+			var avgLatency int64
 			if pool.nLatency > 0 {
 				avgLatency = pool.sumLatency / pool.nLatency
+			} else {
+				avgLatency = 0
 			}
 			taskLog.Printf("tasks=%d, average_latency(ms)=%d", pool.totalTask, avgLatency)
 		}

--- a/src/common/stats.go
+++ b/src/common/stats.go
@@ -50,7 +50,7 @@ type snapshotMsg struct {
 }
 
 var initOnce sync.Once
-var statsChan chan any = make(chan any, 256)
+var statsChan = make(chan any, 256)
 
 func initTaskOnce() {
 	initOnce.Do(func() {

--- a/src/main.go
+++ b/src/main.go
@@ -125,10 +125,8 @@ func overrideOpts(confPath, overridePath, optsStr string) error {
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(overridePath, s, 0644); err != nil {
-		return err
-	}
-	return nil
+
+	return ioutil.WriteFile(overridePath, s, 0644)
 }
 
 // corresponds to the "pprof mem" command of the admin tool.

--- a/src/worker/helpers.go
+++ b/src/worker/helpers.go
@@ -28,11 +28,10 @@ func initOLBaseDir(baseDir string, dockerBaseImage string) error {
 	fmt.Printf("\tExtract '%s' Docker image to %s (make take several minutes).\n", dockerBaseImage, baseDir)
 
 	// PART 1: dump Docker image
-	var dockerClient *docker.Client
-	if c, err := docker.NewClientFromEnv(); err != nil {
+	dockerClient, err := docker.NewClientFromEnv()
+	if err != nil {
 		return err
 	}
-	dockerClient = c
 
 	err := dutil.DumpDockerImage(dockerClient, dockerBaseImage, baseDir)
 	if err != nil {

--- a/src/worker/helpers.go
+++ b/src/worker/helpers.go
@@ -31,9 +31,8 @@ func initOLBaseDir(baseDir string, dockerBaseImage string) error {
 	var dockerClient *docker.Client
 	if c, err := docker.NewClientFromEnv(); err != nil {
 		return err
-	} else {
-		dockerClient = c
 	}
+	dockerClient = c
 
 	err := dutil.DumpDockerImage(dockerClient, dockerBaseImage, baseDir)
 	if err != nil {
@@ -74,11 +73,8 @@ func initOLBaseDir(baseDir string, dockerBaseImage string) error {
 	}
 
 	path = filepath.Join(baseDir, "dev", "urandom")
-	if err := exec.Command("mknod", "-m", "0644", path, "c", "1", "9").Run(); err != nil {
-		return err
-	}
 
-	return nil
+	return exec.Command("mknod", "-m", "0644", path, "c", "1", "9").Run()
 }
 
 // initOLDir prepares a directory at olPath with necessary files for a
@@ -281,8 +277,5 @@ func overrideOpts(confPath, overridePath, optsStr string) error {
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(overridePath, s, 0644); err != nil {
-		return err
-	}
-	return nil
+	return ioutil.WriteFile(overridePath, s, 0644)
 }

--- a/src/worker/helpers.go
+++ b/src/worker/helpers.go
@@ -33,8 +33,7 @@ func initOLBaseDir(baseDir string, dockerBaseImage string) error {
 		return err
 	}
 
-	err := dutil.DumpDockerImage(dockerClient, dockerBaseImage, baseDir)
-	if err != nil {
+	if err = dutil.DumpDockerImage(dockerClient, dockerBaseImage, baseDir); err != nil {
 		return err
 	}
 

--- a/src/worker/lambda/handlerPuller.go
+++ b/src/worker/lambda/handlerPuller.go
@@ -19,7 +19,7 @@ import (
 	"github.com/open-lambda/open-lambda/ol/common"
 )
 
-var notFound404 = errors.New("file does not exist")
+var errNotFound404 = errors.New("file does not exist")
 
 // TODO: for web registries, support an HTTP-based access key
 // (https://en.wikipedia.org/wiki/Basic_access_authentication)
@@ -130,31 +130,31 @@ func (cp *HandlerPuller) Pull(name string) (rt_type common.RuntimeType, targetDi
 			rt_type, targetDir, err = cp.pullRemoteFile(urls[i], name)
 			if err == nil {
 				return rt_type, targetDir, nil
-			} else if err != notFound404 {
+			} else if err != errNotFound404 {
 				// 404 is OK, because we just go on to check the next URLs
 				return rt_type, "", err
 			}
 		}
 
 		return rt_type, "", fmt.Errorf("lambda not found at any of these locations: %s", strings.Join(urls, ", "))
-	} else {
-		// registry type = file
-		paths := []string{
-			filepath.Join(cp.prefix, name) + ".tar.gz",
-			filepath.Join(cp.prefix, name) + ".py",
-			filepath.Join(cp.prefix, name) + ".bin",
-			filepath.Join(cp.prefix, name),
-		}
-
-		for i := 0; i < len(paths); i++ {
-			if _, err := os.Stat(paths[i]); !os.IsNotExist(err) {
-				rt_type, targetDir, err = cp.pullLocalFile(paths[i], name)
-				return rt_type, targetDir, err
-			}
-		}
-
-		return rt_type, "", fmt.Errorf("lambda not found at any of these locations: %s", strings.Join(paths, ", "))
 	}
+
+	// registry type = file
+	paths := []string{
+		filepath.Join(cp.prefix, name) + ".tar.gz",
+		filepath.Join(cp.prefix, name) + ".py",
+		filepath.Join(cp.prefix, name) + ".bin",
+		filepath.Join(cp.prefix, name),
+	}
+
+	for i := 0; i < len(paths); i++ {
+		if _, err := os.Stat(paths[i]); !os.IsNotExist(err) {
+			rt_type, targetDir, err = cp.pullLocalFile(paths[i], name)
+			return rt_type, targetDir, err
+		}
+	}
+
+	return rt_type, "", fmt.Errorf("lambda not found at any of these locations: %s", strings.Join(paths, ", "))
 }
 
 // delete any caching associated with this handler
@@ -210,9 +210,9 @@ func (cp *HandlerPuller) pullLocalFile(src, lambdaName string) (rt_type common.R
 	targetDir = cp.dirMaker.Get(lambdaName)
 	if err := os.Mkdir(targetDir, os.ModeDir); err != nil {
 		return rt_type, "", err
-	} else {
-		log.Printf("Created new directory for lambda function at `%s`", targetDir)
 	}
+
+	log.Printf("Created new directory for lambda function at `%s`", targetDir)
 
 	// Make sure we include the suffix
 	if strings.HasSuffix(stat.Name(), ".py") {
@@ -224,8 +224,6 @@ func (cp *HandlerPuller) pullLocalFile(src, lambdaName string) (rt_type common.R
 		if err != nil {
 			return rt_type, "", fmt.Errorf("%s :: %s", err)
 		}
-
-
 	} else if strings.HasSuffix(stat.Name(), ".bin") {
 		log.Printf("Installing `%s` from binary file", src)
 
@@ -235,7 +233,6 @@ func (cp *HandlerPuller) pullLocalFile(src, lambdaName string) (rt_type common.R
 		if err != nil {
 			return rt_type, "", fmt.Errorf("%s :: %s", err)
 		}
-
 	} else if strings.HasSuffix(stat.Name(), ".tar.gz") {
 		log.Printf("Installing `%s` from an archive file", src)
 
@@ -284,7 +281,7 @@ func (cp *HandlerPuller) pullRemoteFile(src, lambdaName string) (rt_type common.
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return rt_type, "", notFound404
+		return rt_type, "", errNotFound404
 	}
 
 	if resp.StatusCode == http.StatusNotModified {

--- a/src/worker/lambda/lambdaFunction.go
+++ b/src/worker/lambda/lambdaFunction.go
@@ -222,7 +222,7 @@ func (f *LambdaFunc) Task() {
 	// stats for autoscaling
 	outstandingReqs := 0
 	execMs := common.NewRollingAvg(10)
-	var lastScaling *time.Time = nil
+	var lastScaling *time.Time
 	timeout := time.NewTimer(0)
 
 	for {

--- a/src/worker/lambda/lambdaInstance.go
+++ b/src/worker/lambda/lambdaInstance.go
@@ -37,7 +37,7 @@ type LambdaInstance struct {
 func (linst *LambdaInstance) Task() {
 	f := linst.lfunc
 
-	var sb sandbox.Sandbox = nil
+	var sb sandbox.Sandbox
 	var err error
 
 	for {
@@ -91,7 +91,6 @@ func (linst *LambdaInstance) Task() {
 				sb = nil
 			}
 			t2.T1()
-
 		}
 
 		// if we don't already have a Sandbox, create one, and

--- a/src/worker/lambda/zygote/importCache.go
+++ b/src/worker/lambda/zygote/importCache.go
@@ -166,7 +166,6 @@ func (cache *ImportCache) Create(childSandboxPool sandbox.SandboxPool, isLeaf bo
 func (cache *ImportCache) createChildSandboxFromNode(
 	childSandboxPool sandbox.SandboxPool, node *ImportCacheNode, isLeaf bool,
 	codeDir, scratchDir string, meta *sandbox.SandboxMeta, rt_type common.RuntimeType) (sandbox.Sandbox, error) {
-
 	t := common.T0("ImportCache.createChildSandboxFromNode")
 	defer t.T1()
 
@@ -235,14 +234,14 @@ func (cache *ImportCache) getSandboxInNode(node *ImportCacheNode, forceNew bool,
 		}
 		node.sbRefCount += 1
 		return node.sb, false, nil
-	} else {
-		// SLOW PATH
-		if err := cache.createSandboxInNode(node, rt_type); err != nil {
-			return nil, false, err
-		}
-		node.sbRefCount = 1
-		return node.sb, true, nil
 	}
+
+	// SLOW PATH
+	if err := cache.createSandboxInNode(node, rt_type); err != nil {
+		return nil, false, err
+	}
+	node.sbRefCount = 1
+	return node.sb, true, nil
 }
 
 // decrease refs to SB, pausing if nobody else is still using it

--- a/src/worker/sandbox/debugger.go
+++ b/src/worker/sandbox/debugger.go
@@ -11,8 +11,8 @@ type debugger chan any
 
 func newDebugger(sbPool SandboxPool) debugger {
 	var d debugger = make(chan any, 64)
-	sbPool.AddListener(func(EvType SandboxEventType, sb Sandbox) {
-		d <- SandboxEvent{EvType, sb}
+	sbPool.AddListener(func(evType SandboxEventType, sb Sandbox) {
+		d <- SandboxEvent{evType, sb}
 	})
 	go d.Run()
 	return d

--- a/src/worker/sandbox/safeSandbox.go
+++ b/src/worker/sandbox/safeSandbox.go
@@ -51,7 +51,7 @@ func (sb *safeSandbox) startNotifyingListeners(eventHandlers []SandboxEventFunc)
 }
 
 // like regular printf, with suffix indicating which sandbox produced the message
-func (sb *safeSandbox) printf(format string, args ...interface{}) {
+func (sb *safeSandbox) printf(format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
 	log.Printf("%s [SB %s]", strings.TrimRight(msg, "\n"), sb.Sandbox.ID())
 }

--- a/src/worker/sandbox/sockPool.go
+++ b/src/worker/sandbox/sockPool.go
@@ -20,7 +20,7 @@ import (
 const SOCK_HOST_INIT = "/usr/local/bin/sock-init"
 const SOCK_GUEST_INIT = "/ol-init"
 
-var nextId int64 = 0
+var nextId int64
 
 // SOCKPool is a ContainerFactory that creats docker containeres.
 type SOCKPool struct {
@@ -75,7 +75,7 @@ func (pool *SOCKPool) Create(parent Sandbox, isLeaf bool, codeDir, scratchDir st
 	t := common.T0("Create()")
 	defer t.T1()
 
-	var cSock *SOCKContainer = &SOCKContainer{
+	var cSock = &SOCKContainer{
 		pool:             pool,
 		id:               id,
 		containerRootDir: pool.rootDirs.Make("SB-" + id),

--- a/src/worker/server/server.go
+++ b/src/worker/server/server.go
@@ -35,11 +35,11 @@ type cleanable interface {
 
 // temporary file storing cpu profiled data
 const CPU_TEMP_PATTERN = ".cpu.*.prof"
-var cpuTemp *os.File = nil
+var cpuTemp *os.File
 var lock sync.Mutex
 
-// GetPid returns process ID, useful for making sure we're talking to the expected server
-func GetPid(w http.ResponseWriter, r *http.Request) {
+// HandleGetPid returns process ID, useful for making sure we're talking to the expected server
+func HandleGetPid(w http.ResponseWriter, r *http.Request) {
 	// TODO re-enable once logging is configurable
 	//log.Printf("Received request to %s\n", r.URL.Path)
 
@@ -218,7 +218,7 @@ func Main() (err error) {
 	}
 
 	// things shared by all servers
-	http.HandleFunc(PID_PATH, GetPid)
+	http.HandleFunc(PID_PATH, HandleGetPid)
 	http.HandleFunc(STATUS_PATH, Status)
 	http.HandleFunc(STATS_PATH, Stats)
 	http.HandleFunc(PPROF_MEM_PATH, PprofMem)

--- a/src/worker/server/sockServer.go
+++ b/src/worker/server/sockServer.go
@@ -46,7 +46,7 @@ func (server *SOCKServer) Create(w http.ResponseWriter, rsrc []string, args map[
 	// create args
 	codeDir := args["code"].(string)
 
-	var parent sandbox.Sandbox = nil
+	var parent sandbox.Sandbox
 	if p, ok := args["parent"]; ok && p != "" {
 		parent = server.GetSandbox(p.(string))
 		if parent == nil {


### PR DESCRIPTION
This should make reviewing pull request a little easier.

For now, most lints are still disabled. Enabling them and fixing lint failures on the existing code base might be a good first issue for students.