### PR TITLE
Enabled unused-parameters and unused-receivers lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Install pylint
       run: pip3 install pylint==2.15.0
     - name: Install revive (go linter)
-      run: go get github.com/mgechev/revive@v1.3.4
+      run: go install github.com/mgechev/revive@v1.3.4
     - name: Install cross
       run: cargo install cross
     - name: Build OpenLambda

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Install pylint
       run: pip3 install pylint==2.15.0
     - name: Install revive (go linter)
-      run: go install github.com/mgechev/revive@latest
+      run: go get github.com/mgechev/revive@v1.3.4
     - name: Install cross
       run: cargo install cross
     - name: Build OpenLambda

--- a/golint.toml
+++ b/golint.toml
@@ -28,10 +28,6 @@ enableAllRules = true
     Disabled = true
 [rule.import-shadowing]
     Disabled = true
-[rule.unused-parameter]
-    Disabled = true
-[rule.unused-receiver]
-    Disabled = true
 [rule.receiver-naming]
     Disabled = true
 [rule.error-strings]

--- a/golint.toml
+++ b/golint.toml
@@ -1,4 +1,6 @@
 enableAllRules = true
+errorCode = 2
+#warningCode = 1
 
 #TODO we should eventually comment all public methods
 [rule.package-comments]

--- a/src/bench/bench.go
+++ b/src/bench/bench.go
@@ -19,7 +19,7 @@ type Call struct {
 	name string
 }
 
-func task(task int, reqQ chan Call, errQ chan error) {
+func task(_ int, reqQ chan Call, errQ chan error) {
 	for {
 		call, ok := <-reqQ
 		if !ok {

--- a/src/boss/boss.go
+++ b/src/boss/boss.go
@@ -44,7 +44,7 @@ func (b *Boss) BossStatus(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (b *Boss) Close(w http.ResponseWriter, r *http.Request) {
+func (b *Boss) Close(_ http.ResponseWriter, _ *http.Request) {
 	b.workerPool.Close()
 	if Conf.Scaling == "threshold-scaler" {
 		b.autoScaler.Close()

--- a/src/boss/cloudvm/gcp_worker.go
+++ b/src/boss/cloudvm/gcp_worker.go
@@ -79,7 +79,7 @@ func NewGcpWorkerPool() *WorkerPool {
 	}
 }
 
-func (pool *GcpWorkerPool) NewWorker(workerId string) *Worker {
+func (_ *GcpWorkerPool) NewWorker(workerId string) *Worker {
 	return &Worker{
 		workerId:       workerId,
 		workerIp:       "",
@@ -113,6 +113,6 @@ func (pool *GcpWorkerPool) DeleteInstance(worker *Worker) {
 	pool.client.Wait(pool.client.deleteGcpInstance(worker.workerId)) //wait until instance is completely deleted
 }
 
-func (pool *GcpWorkerPool) ForwardTask(w http.ResponseWriter, r *http.Request, worker *Worker) {
+func (_ *GcpWorkerPool) ForwardTask(w http.ResponseWriter, r *http.Request, worker *Worker) {
 	forwardTaskHelper(w, r, worker.workerIp)
 }

--- a/src/boss/cloudvm/mock_worker.go
+++ b/src/boss/cloudvm/mock_worker.go
@@ -21,22 +21,22 @@ func NewMockWorkerPool() *WorkerPool {
 	}
 }
 
-func (pool *MockWorkerPool) NewWorker(workerId string) *Worker {
+func (_ *MockWorkerPool) NewWorker(workerId string) *Worker {
 	return &Worker{
 		workerId: workerId,
 		workerIp: "",
 	}
 }
 
-func (pool *MockWorkerPool) CreateInstance(worker *Worker) {
+func (_ *MockWorkerPool) CreateInstance(worker *Worker) {
 	log.Printf("created new mock worker: %s\n", worker.workerId)
 }
 
-func (pool *MockWorkerPool) DeleteInstance(worker *Worker) {
+func (_ *MockWorkerPool) DeleteInstance(worker *Worker) {
 	log.Printf("deleted mock worker: %s\n", worker.workerId)
 }
 
-func (pool *MockWorkerPool) ForwardTask(w http.ResponseWriter, r *http.Request, worker *Worker) {
+func (_ *MockWorkerPool) ForwardTask(w http.ResponseWriter, _ *http.Request, worker *Worker) {
 	s := fmt.Sprintf("hello from %s\n", worker.workerId)
 	w.WriteHeader(http.StatusOK)
 	_, err := w.Write([]byte(s))

--- a/src/worker/helpers.go
+++ b/src/worker/helpers.go
@@ -170,7 +170,7 @@ func initOLDir(olPath string, dockerBaseImage string, newBase bool) (err error) 
 // main error scenarios:
 // 1. PID exists, but process cannot be killed (worker probably died unexpectedly)
 // 2. The cleanup is taking too long (maybe the timeout is insufficient, or there is a deadlock)
-func stopOL(olPath string) error {
+func stopOL(_ string) error {
 	// locate worker.pid, use it to get worker's PID
 	pidPath := filepath.Join(common.Conf.Worker_dir, "worker.pid")
 	data, err := ioutil.ReadFile(pidPath)

--- a/src/worker/lambda/lambdaManager.go
+++ b/src/worker/lambda/lambdaManager.go
@@ -131,7 +131,7 @@ func (mgr *LambdaMgr) Debug() string {
 	return mgr.sbPool.DebugString() + "\n"
 }
 
-func (mgr *LambdaMgr) DumpStatsToLog() {
+func (_ *LambdaMgr) DumpStatsToLog() {
 	snapshot := common.SnapshotStats()
 
 	sec := func(name string) float64 {

--- a/src/worker/sandbox/cgroups/pool.go
+++ b/src/worker/sandbox/cgroups/pool.go
@@ -164,12 +164,15 @@ func (pool *CgroupPool) GetCg(memLimitMB int, moveMemCharge bool, cpuPercent int
 	cg.SetMemLimitMB(memLimitMB)
 	cg.SetCPUPercent(cpuPercent)
 
-	/* FIXME not supported in CG2?
-	   if moveMemCharge {
-	       cg.WriteInt("memory.move_charge_at_immigrate", 1)
-	   } else {
-	       cg.WriteInt("memory.move_charge_at_immigrate", 0)
-	   }*/
+	// FIXME not supported in CG2?
+	var _ = moveMemCharge
+
+	/*
+	if moveMemCharge {
+		cg.WriteInt("memory.move_charge_at_immigrate", 1)
+	} else {
+		cg.WriteInt("memory.move_charge_at_immigrate", 0)
+	}*/
 
 	return cg
 }

--- a/src/worker/sandbox/docker.go
+++ b/src/worker/sandbox/docker.go
@@ -169,7 +169,7 @@ func (container *DockerContainer) Unpause() error {
 }
 
 // Destroy shuts down this container
-func (container *DockerContainer) Destroy(reason string) {
+func (container *DockerContainer) Destroy(_ string) {
 	if err := container.internalDestroy(); err != nil {
 		panic(fmt.Sprintf("Failed to cleanup container %v: %v", container.container.ID, err))
 	}
@@ -296,11 +296,11 @@ func (container *DockerContainer) DebugString() string {
 	return fmt.Sprintf("SANDBOX %s (DOCKER)\n", container.ID())
 }
 
-func (*DockerContainer) fork(dst Sandbox) (err error) {
+func (*DockerContainer) fork(_ Sandbox) (err error) {
 	panic("DockerContainer does not implement cross-container forks")
 }
 
-func (*DockerContainer) childExit(child Sandbox) {
+func (*DockerContainer) childExit(_ Sandbox) {
 	panic("DockerContainers should not have children because fork is unsupported")
 }
 

--- a/src/worker/sandbox/dockerPool.go
+++ b/src/worker/sandbox/dockerPool.go
@@ -60,7 +60,7 @@ func NewDockerPool(pidMode string, caps []string) (*DockerPool, error) {
 }
 
 // Create creates a docker sandbox from the handler and sandbox directory.
-func (pool *DockerPool) Create(parent Sandbox, isLeaf bool, codeDir, scratchDir string, meta *SandboxMeta, _rtType common.RuntimeType) (sb Sandbox, err error) {
+func (pool *DockerPool) Create(parent Sandbox, isLeaf bool, codeDir, scratchDir string, meta *SandboxMeta, _ common.RuntimeType) (sb Sandbox, err error) {
 	meta = fillMetaDefaults(meta)
 	t := common.T0("Create()")
 	defer t.T1()
@@ -161,7 +161,7 @@ func (pool *DockerPool) Create(parent Sandbox, isLeaf bool, codeDir, scratchDir 
 
 // Cleanup will free up any unneeded data/resources
 // Currently, this function does nothing and cleanup is handled by the docker daemon
-func (pool *DockerPool) Cleanup() {}
+func (_ *DockerPool) Cleanup() {}
 
 // DebugString returns debug information
 func (pool *DockerPool) DebugString() string {

--- a/src/worker/sandbox/evictors.go
+++ b/src/worker/sandbox/evictors.go
@@ -110,7 +110,7 @@ func (evictor *SOCKEvictor) nextEvent(block bool) *SandboxEvent {
 	}
 }
 
-func (evictor *SOCKEvictor) printf(format string, args ...any) {
+func (_ *SOCKEvictor) printf(format string, args ...any) {
 	if common.Conf.Trace.Evictor {
 		msg := fmt.Sprintf(format, args...)
 		log.Printf("%s [EVICTOR]", strings.TrimRight(msg, "\n"))

--- a/src/worker/sandbox/forkRequest.go
+++ b/src/worker/sandbox/forkRequest.go
@@ -101,7 +101,7 @@ import (
  *
  * Returns the PID of the spawned process upon success.
  */
-func (c *SOCKContainer) forkRequest(fileSockPath string, rootDir *os.File, memCG *os.File) error {
+func (_ *SOCKContainer) forkRequest(fileSockPath string, rootDir *os.File, memCG *os.File) error {
 	cSock := C.CString(fileSockPath)
 	defer C.free(unsafe.Pointer(cSock))
 

--- a/src/worker/sandbox/sock.go
+++ b/src/worker/sandbox/sock.go
@@ -269,7 +269,7 @@ func (container *SOCKContainer) Unpause() (err error) {
 }
 
 // Destroy shuts down the container
-func (container *SOCKContainer) Destroy(reason string) {
+func (container *SOCKContainer) Destroy(_ string) {
 	if err := container.cg.Pause(); err != nil {
 		panic(err)
 	}

--- a/src/worker/server/lambdaServer.go
+++ b/src/worker/server/lambdaServer.go
@@ -67,7 +67,7 @@ func (s *LambdaServer) RunLambda(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *LambdaServer) Debug(w http.ResponseWriter, r *http.Request) {
+func (s *LambdaServer) Debug(w http.ResponseWriter, _ *http.Request) {
 	w.Write([]byte(s.lambdaMgr.Debug()))
 }
 

--- a/src/worker/server/server.go
+++ b/src/worker/server/server.go
@@ -39,7 +39,7 @@ var cpuTemp *os.File
 var lock sync.Mutex
 
 // HandleGetPid returns process ID, useful for making sure we're talking to the expected server
-func HandleGetPid(w http.ResponseWriter, r *http.Request) {
+func HandleGetPid(w http.ResponseWriter, _ *http.Request) {
 	// TODO re-enable once logging is configurable
 	//log.Printf("Received request to %s\n", r.URL.Path)
 
@@ -50,7 +50,7 @@ func HandleGetPid(w http.ResponseWriter, r *http.Request) {
 }
 
 // Status writes "ready" to the response.
-func Status(w http.ResponseWriter, r *http.Request) {
+func Status(w http.ResponseWriter, _ *http.Request) {
 	// TODO re-enable once logging is configurable
 	//log.Printf("Received request to %s\n", r.URL.Path)
 
@@ -59,7 +59,7 @@ func Status(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func Stats(w http.ResponseWriter, r *http.Request) {
+func Stats(w http.ResponseWriter, _ *http.Request) {
 	//log.Printf("Received request to %s\n", r.URL.Path)
 	snapshot := common.SnapshotStats()
 	if b, err := json.MarshalIndent(snapshot, "", "\t"); err != nil {
@@ -69,7 +69,7 @@ func Stats(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func PprofMem(w http.ResponseWriter, r *http.Request) {
+func PprofMem(w http.ResponseWriter, _ *http.Request) {
 	runtime.GC()
 	w.Header().Add("Content-Type", "application/octet-stream")
 	if err := pprof.WriteHeapProfile(w); err != nil {
@@ -106,7 +106,7 @@ func doCpuStart() error {
 }
 
 // Starts CPU profiling
-func PprofCpuStart(w http.ResponseWriter, r *http.Request) {
+func PprofCpuStart(w http.ResponseWriter, _ *http.Request) {
 	if err := doCpuStart(); err != nil {
 		msg := fmt.Sprintf("%v", err)
 		w.WriteHeader(http.StatusBadRequest)
@@ -117,7 +117,7 @@ func PprofCpuStart(w http.ResponseWriter, r *http.Request) {
 }
 
 // Stops CPU profiling, writes profiled data to response, and does cleanup
-func PprofCpuStop(w http.ResponseWriter, r *http.Request) {
+func PprofCpuStop(w http.ResponseWriter, _ *http.Request) {
 	lock.Lock()
 	defer lock.Unlock()
 

--- a/src/worker/server/sockServer.go
+++ b/src/worker/server/sockServer.go
@@ -35,7 +35,7 @@ func (server *SOCKServer) GetSandbox(id string) sandbox.Sandbox {
 	return val.(sandbox.Sandbox)
 }
 
-func (server *SOCKServer) Create(w http.ResponseWriter, rsrc []string, args map[string]any) error {
+func (server *SOCKServer) Create(w http.ResponseWriter, _ []string, args map[string]any) error {
 	var leaf bool
 	if b, ok := args["leaf"]; !ok || b.(bool) {
 		leaf = true
@@ -100,7 +100,7 @@ func (server *SOCKServer) Create(w http.ResponseWriter, rsrc []string, args map[
 	return nil
 }
 
-func (server *SOCKServer) Destroy(w http.ResponseWriter, rsrc []string, args map[string]any) error {
+func (server *SOCKServer) Destroy(_ http.ResponseWriter, rsrc []string, _ map[string]any) error {
 	c := server.GetSandbox(rsrc[0])
 	if c == nil {
 		return fmt.Errorf("no sandbox found with ID '%s'", rsrc[0])
@@ -111,7 +111,7 @@ func (server *SOCKServer) Destroy(w http.ResponseWriter, rsrc []string, args map
 	return nil
 }
 
-func (server *SOCKServer) Pause(w http.ResponseWriter, rsrc []string, args map[string]any) error {
+func (server *SOCKServer) Pause(_ http.ResponseWriter, rsrc []string, _ map[string]any) error {
 	c := server.GetSandbox(rsrc[0])
 	if c == nil {
 		return fmt.Errorf("no sandbox found with ID '%s'", rsrc[0])
@@ -120,7 +120,7 @@ func (server *SOCKServer) Pause(w http.ResponseWriter, rsrc []string, args map[s
 	return c.Pause()
 }
 
-func (server *SOCKServer) Unpause(w http.ResponseWriter, rsrc []string, args map[string]any) error {
+func (server *SOCKServer) Unpause(_ http.ResponseWriter, rsrc []string, _ map[string]any) error {
 	c := server.GetSandbox(rsrc[0])
 	if c == nil {
 		return fmt.Errorf("no sandbox found with ID '%s'", rsrc[0])
@@ -129,7 +129,7 @@ func (server *SOCKServer) Unpause(w http.ResponseWriter, rsrc []string, args map
 	return c.Unpause()
 }
 
-func (server *SOCKServer) Debug(w http.ResponseWriter, rsrc []string, args map[string]any) error {
+func (server *SOCKServer) Debug(w http.ResponseWriter, _ []string, _ map[string]any) error {
 	str := server.sbPool.DebugString()
 	fmt.Printf("%s\n", str)
 	w.Write([]byte(str))


### PR DESCRIPTION
This should help prevent some bugs in the future.

Unfortunately, the linter insists on naming variables as `_`. I think `_foo` would be more descriptive, but there is no option to allow that, it seems.