### PR TITLE
Fix comment spacing warning

### DIFF
--- a/golint.toml
+++ b/golint.toml
@@ -18,6 +18,11 @@ errorCode = 2
 [rule.var-naming]
     Disabled = true
 
+# Eventually we want to update all warnings to errors
+# For now, we disable them one by one
+[rule.comment-spacings]
+    severity = "error"
+
 [rule.defer]
     Disabled = true
 [rule.empty-block]

--- a/src/boss/autoscaling/scaling.go
+++ b/src/boss/autoscaling/scaling.go
@@ -3,7 +3,7 @@ package autoscaling
 import "github.com/open-lambda/open-lambda/ol/boss/cloudvm"
 
 type Scaling interface {
-	Launch(pool *cloudvm.WorkerPool) //launch auto-scaler
-	Scale() //makes scaling decision based on cluster status
-	Close() //close auto-scaler
+	Launch(pool *cloudvm.WorkerPool) // launch auto-scaler
+	Scale() // makes scaling decision based on cluster status
+	Close() // close auto-scaler
 }

--- a/src/boss/autoscaling/threshold.go
+++ b/src/boss/autoscaling/threshold.go
@@ -22,7 +22,7 @@ func (s *ThresholdScaling) Launch(pool *cloudvm.WorkerPool) {
 	s.pool = pool
 	s.exitChan = make(chan bool)
 	log.Println("lauching threshold-scaler")
-	pool.SetTarget(1) //initial cluster size set to 1
+	pool.SetTarget(1) // initial cluster size set to 1
 	go func() {
 		for {
 			s.Scale()

--- a/src/boss/boss.go
+++ b/src/boss/boss.go
@@ -91,7 +91,7 @@ func (b *Boss) ScalingWorker(w http.ResponseWriter, r *http.Request) {
 	// STEP 2: adjust target worker count
 	b.workerPool.SetTarget(worker_count)
 	
-	//respond with status
+	// respond with status
 	b.BossStatus(w, r)
 }
 

--- a/src/boss/cloudvm/api.go
+++ b/src/boss/cloudvm/api.go
@@ -22,9 +22,9 @@ const (
 Defines the interface for platform-specific functions
 */
 type WorkerPoolPlatform interface {
-	NewWorker(workerId string) *Worker //return new worker struct
-	CreateInstance(worker *Worker)     //create new instance in the cloud platform
-	DeleteInstance(worker *Worker)     //delete cloud platform instance associated with give worker struct
+	NewWorker(workerId string) *Worker // return new worker struct
+	CreateInstance(worker *Worker)     // create new instance in the cloud platform
+	DeleteInstance(worker *Worker)     // delete cloud platform instance associated with give worker struct
 	ForwardTask(w http.ResponseWriter, r *http.Request, worker *Worker)
 }
 

--- a/src/boss/cloudvm/azure.go
+++ b/src/boss/cloudvm/azure.go
@@ -25,7 +25,7 @@ var err error
 var containerClient azblob.ContainerClient
 
 func Create(contents string) {
-	url := "https://openlambda.blob.core.windows.net/" //replace <StorageAccountName> with your Azure storage account name
+	url := "https://openlambda.blob.core.windows.net/" // replace <StorageAccountName> with your Azure storage account name
 	ctx := context.Background()
 	// Create a default request pipeline using your storage account name and account key.
 	credential, err := azidentity.NewDefaultAzureCredential(nil)
@@ -115,7 +115,7 @@ func randomString() string {
 func AzureMain(contents string) {
 	fmt.Printf("Azure Blob storage quick start sample\n")
 
-	url := "https://<StorageAccountName>.blob.core.windows.net/" //replace <StorageAccountName> with your Azure storage account name
+	url := "https://<StorageAccountName>.blob.core.windows.net/" // replace <StorageAccountName> with your Azure storage account name
 	ctx := context.Background()
 
 	// Create a default request pipeline using your storage account name and account key.

--- a/src/boss/cloudvm/gcp.go
+++ b/src/boss/cloudvm/gcp.go
@@ -90,7 +90,7 @@ func GcpBossTest() {
 	start = time.Now()
 	resp, err = client.Wait(client.LaunchGcp("test-snap", "test-vm"))
 	clone_time := time.Since(start)
-	if err != nil && resp["error"].(map[string]any)["code"] != "409" { //continue if instance already exists error
+	if err != nil && resp["error"].(map[string]any)["code"] != "409" { // continue if instance already exists error
 		fmt.Printf("instance alreay exists!\n")
 		client.startGcpInstance("test-vm")
 	} else if err != nil {
@@ -384,7 +384,7 @@ func (c *GcpClient) GcpIPtoInstance() (map[string]string, error) {
 		instance_name := item.(map[string]any)["name"].(string)
 		interfaces := item.(map[string]any)["networkInterfaces"]
 		for _, netif := range interfaces.([]any) {
-			ip := netif.(map[string]any)["networkIP"].(string) //internal ip
+			ip := netif.(map[string]any)["networkIP"].(string) // internal ip
 			lookup[ip] = instance_name
 		}
 	}
@@ -492,7 +492,7 @@ func (c *GcpClient) LaunchGcp(snapshotName string, vmName string) (map[string]an
 		Region:              c.service_account["region"].(string),
 		Zone:                c.service_account["zone"].(string),
 		InstanceName:        vmName,
-		//SourceImage: "projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20220204",
+		// SourceImage: "projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20220204",
 		SnapshotName:        snapshotName,
 		DiskSizeGb:          GcpConf.DiskSizeGb,
 		MachineType:         GcpConf.MachineType,
@@ -510,7 +510,8 @@ func (c *GcpClient) LaunchGcp(snapshotName string, vmName string) (map[string]an
 	return c.post(url, payload)
 }
 
-func (c *GcpClient) startGcpInstance(vmName string) (map[string]any, error) { //start existing instance
+// start existing instance
+func (c *GcpClient) startGcpInstance(vmName string) (map[string]any, error) {
 	url := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/instances/%s/start",
 		c.service_account["project_id"].(string),
 		c.service_account["zone"].(string),

--- a/src/boss/cloudvm/gcp_rest.go
+++ b/src/boss/cloudvm/gcp_rest.go
@@ -6,7 +6,7 @@ type GcpLaunchVmArgs struct {
 	Region              string
 	Zone                string
 	InstanceName        string
-	//SourceImage string
+	// SourceImage string
 	SnapshotName        string
 	DiskSizeGb          int
 	MachineType         string

--- a/src/boss/cloudvm/gcp_worker.go
+++ b/src/boss/cloudvm/gcp_worker.go
@@ -90,9 +90,9 @@ func (pool *GcpWorkerPool) CreateInstance(worker *Worker) {
 	client := pool.client
 	fmt.Printf("creating new VM from snapshot\n")
 
-	resp, err := client.Wait(client.LaunchGcp("boss-snap", worker.workerId)) //TODO: load snapshot name from Config
+	resp, err := client.Wait(client.LaunchGcp("boss-snap", worker.workerId)) // TODO: load snapshot name from Config
 
-	if err != nil && resp["error"].(map[string]any)["code"] != "409" { //continue if instance already exists error
+	if err != nil && resp["error"].(map[string]any)["code"] != "409" { // continue if instance already exists error
 		fmt.Printf("instance alreay exists!\n")
 		client.startGcpInstance(worker.workerId)
 	} else if err != nil {
@@ -110,7 +110,7 @@ func (pool *GcpWorkerPool) CreateInstance(worker *Worker) {
 func (pool *GcpWorkerPool) DeleteInstance(worker *Worker) {
 	log.Printf("deleting gcp worker: %s\n", worker.workerId)
 	worker.runCmd("./ol worker down")
-	pool.client.Wait(pool.client.deleteGcpInstance(worker.workerId)) //wait until instance is completely deleted
+	pool.client.Wait(pool.client.deleteGcpInstance(worker.workerId)) // wait until instance is completely deleted
 }
 
 func (_ *GcpWorkerPool) ForwardTask(w http.ResponseWriter, r *http.Request, worker *Worker) {

--- a/src/boss/cloudvm/mock_worker.go
+++ b/src/boss/cloudvm/mock_worker.go
@@ -8,11 +8,11 @@ import (
 
 // WORKER IMPLEMENTATION: MockWorker
 type MockWorkerPool struct {
-	//no platform specific attributes
+	// no platform specific attributes
 }
 
 type MockWorker struct {
-	//no platform specific attributes
+	// no platform specific attributes
 }
 
 func NewMockWorkerPool() *WorkerPool {

--- a/src/worker/lambda/lambdaFunction.go
+++ b/src/worker/lambda/lambdaFunction.go
@@ -291,7 +291,7 @@ func (f *LambdaFunc) Task() {
 				el = el.Next()
 			}
 			if f.codeDir != "" {
-				//cleanupChan <- f.codeDir
+				// cleanupChan <- f.codeDir
 			}
 			close(cleanupChan)
 			<-cleanupTaskDone

--- a/src/worker/lambda/lambdaInstance.go
+++ b/src/worker/lambda/lambdaInstance.go
@@ -132,7 +132,7 @@ func (linst *LambdaInstance) Task() {
 		// serve until we incoming queue is empty
 		t = common.T0("LambdaInstance-ServeRequests")
 		for req != nil {
-			//f.printf("Forwarding request to sandbox")
+			// f.printf("Forwarding request to sandbox")
 
 			t2 := common.T0("LambdaInstance-RoundTrip")
 

--- a/src/worker/sandbox/cgroups/pool.go
+++ b/src/worker/sandbox/cgroups/pool.go
@@ -135,7 +135,7 @@ Empty:
 	done <- true
 }
 
-/// Destroy this entire cgroup pool
+// Destroy this entire cgroup pool
 func (pool *CgroupPool) Destroy() {
 	// signal cgTask, then wait for it to finish
 	ch := make(chan bool)

--- a/src/worker/sandbox/docker.go
+++ b/src/worker/sandbox/docker.go
@@ -234,13 +234,13 @@ func (container *DockerContainer) Logs() (string, error) {
 // GetRuntimeLog returns the log of the runtime
 // Note, this is not supported for docker yet
 func (*DockerContainer) GetRuntimeLog() string {
-	return "" //TODO
+	return "" // TODO
 }
 
 // GetProxyLog returns the log of the http proxy
 // Note, this is not supported for docker yet
 func (*DockerContainer) GetProxyLog() string {
-	return "" //TODO
+	return "" // TODO
 }
 
 // NSPid returns the pid of the first process of the docker container.

--- a/src/worker/sandbox/sock.go
+++ b/src/worker/sandbox/sock.go
@@ -142,7 +142,7 @@ func (container *SOCKContainer) launchContainerProxy() (err error) {
 
 	var pingErr error
 
-	//TODO make more efficient
+	// TODO make this more efficient
 	for i := 0; i < 300; i++ {
 		// check if it has died
 		select {

--- a/src/worker/server/server.go
+++ b/src/worker/server/server.go
@@ -62,7 +62,9 @@ func Status(w http.ResponseWriter, _ *http.Request) {
 func Stats(w http.ResponseWriter, _ *http.Request) {
 	// log.Printf("Received request to %s\n", r.URL.Path)
 	snapshot := common.SnapshotStats()
-	if b, err := json.MarshalIndent(snapshot, "", "\t"); err != nil {
+	b, err := json.MarshalIndent(snapshot, "", "\t")
+
+	if err != nil {
 		panic(err)
 	}
 

--- a/src/worker/server/server.go
+++ b/src/worker/server/server.go
@@ -41,7 +41,7 @@ var lock sync.Mutex
 // HandleGetPid returns process ID, useful for making sure we're talking to the expected server
 func HandleGetPid(w http.ResponseWriter, _ *http.Request) {
 	// TODO re-enable once logging is configurable
-	//log.Printf("Received request to %s\n", r.URL.Path)
+	// log.Printf("Received request to %s\n", r.URL.Path)
 
 	wbody := []byte(strconv.Itoa(os.Getpid()) + "\n")
 	if _, err := w.Write(wbody); err != nil {
@@ -52,7 +52,7 @@ func HandleGetPid(w http.ResponseWriter, _ *http.Request) {
 // Status writes "ready" to the response.
 func Status(w http.ResponseWriter, _ *http.Request) {
 	// TODO re-enable once logging is configurable
-	//log.Printf("Received request to %s\n", r.URL.Path)
+	// log.Printf("Received request to %s\n", r.URL.Path)
 
 	if _, err := w.Write([]byte("ready\n")); err != nil {
 		log.Printf("error in Status: %v", err)
@@ -60,13 +60,13 @@ func Status(w http.ResponseWriter, _ *http.Request) {
 }
 
 func Stats(w http.ResponseWriter, _ *http.Request) {
-	//log.Printf("Received request to %s\n", r.URL.Path)
+	// log.Printf("Received request to %s\n", r.URL.Path)
 	snapshot := common.SnapshotStats()
 	if b, err := json.MarshalIndent(snapshot, "", "\t"); err != nil {
 		panic(err)
-	} else {
-		w.Write(b)
 	}
+
+	w.Write(b)
 }
 
 func PprofMem(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
This removes all instances of the comment spacing warning created by the linter. It also upgrades the warning to an error so that future pull request do not reintroduce it. 

I will try to gradually remove all linter warnings from the codebase, this is the first step.