### PR TITLE
Fix the missing slash in the file path concatenation

### DIFF
--- a/src/worker/lambda/handlerPuller.go
+++ b/src/worker/lambda/handlerPuller.go
@@ -240,7 +240,7 @@ func (cp *HandlerPuller) pullLocalFile(src, lambdaName string) (rt_type common.R
 		}
 
 		// Figure out runtime type
-		if _, err := os.Stat(targetDir + "f.py"); !os.IsNotExist(err) {
+		if _, err := os.Stat(targetDir + "/f.py"); !os.IsNotExist(err) {
 			rt_type = common.RT_PYTHON
 		} else if _, err := os.Stat(targetDir + "/f.bin"); !os.IsNotExist(err) {
 			rt_type = common.RT_NATIVE


### PR DESCRIPTION
This adds a missing slash in the file path concatenation in HandlerPuller, fixes pulling remote files named _*.tar.gz_.

In this instance, `targetDir` does not have a trailing slash, and when concatenated with `f.py`, the resulting path does never exist.