### PR TITLE
New features, including COW and warmup options, are added and configurable

### DIFF
--- a/src/common/config.go
+++ b/src/common/config.go
@@ -75,6 +75,8 @@ type FeaturesConfig struct {
 	Import_cache        string `json:"import_cache"`
 	Downsize_paused_mem bool   `json:"downsize_paused_mem"`
 	Enable_seccomp      bool   `json:"enable_seccomp"`
+	Warmup              bool   `json:"warmup"`
+	COW                 bool   `json:"COW"`
 }
 
 type TraceConfig struct {
@@ -173,6 +175,8 @@ func LoadDefaults(olPath string) error {
 			Import_cache:        "tree",
 			Downsize_paused_mem: true,
 			Enable_seccomp:      true,
+			Warmup:              false,
+			COW:                 true,
 		},
 		Trace: TraceConfig{
 			Cgroups: false,

--- a/src/worker/event/lambdaServer.go
+++ b/src/worker/event/lambdaServer.go
@@ -43,7 +43,6 @@ func (s *LambdaServer) RunLambda(w http.ResponseWriter, r *http.Request) {
 	t := common.T0("web-request")
 	defer t.T1()
 
-	// TODO re-enable logging once it is configurable
 	// log.Printf("Received request to %s\n", r.URL.Path)
 
 	// components represent run[0]/<name_of_sandbox>[1]/<extra_things>...
@@ -82,6 +81,15 @@ func NewLambdaServer() (*LambdaServer, error) {
 	lambdaMgr, err := lambda.NewLambdaMgr()
 	if err != nil {
 		return nil, err
+	}
+
+	warmup := common.Conf.Features.Warmup
+	if warmup {
+		log.Printf("Warming up lambda server")
+		err = lambdaMgr.Warmup()
+		if err != nil {
+			log.Printf("Error warming up lambda server: %s", err.Error())
+		}
 	}
 
 	server := &LambdaServer{

--- a/src/worker/lambda/lambdaInstance.go
+++ b/src/worker/lambda/lambdaInstance.go
@@ -37,7 +37,7 @@ type LambdaInstance struct {
 func (linst *LambdaInstance) Task() {
 	f := linst.lfunc
 
-	var sb sandbox.Sandbox
+	var sb sandbox.Sandbox = nil
 	var err error
 
 	for {

--- a/src/worker/lambda/zygote/api.go
+++ b/src/worker/lambda/zygote/api.go
@@ -9,5 +9,6 @@ type ZygoteProvider interface {
 	Create(childSandboxPool sandbox.SandboxPool, isLeaf bool,
 		codeDir, scratchDir string, meta *sandbox.SandboxMeta,
 		rt_type common.RuntimeType) (sandbox.Sandbox, error)
+	Warmup() error
 	Cleanup()
 }

--- a/src/worker/lambda/zygote/multiTree.go
+++ b/src/worker/lambda/zygote/multiTree.go
@@ -14,6 +14,10 @@ type MultiTree struct {
 	trees []*ImportCache
 }
 
+func (mt *MultiTree) Warmup() error {
+	panic("multi-tree warmup not implemented!")
+}
+
 func NewMultiTree(codeDirs *common.DirMaker, scratchDirs *common.DirMaker, sbPool sandbox.SandboxPool, pp *packages.PackagePuller) (*MultiTree, error) {
 	var tree_count int
 	switch cpus := runtime.NumCPU(); {

--- a/src/worker/sandbox/sockPool.go
+++ b/src/worker/sandbox/sockPool.go
@@ -66,6 +66,9 @@ func sbStr(sb Sandbox) string {
 }
 
 func importLines(modules []string) (string, error) {
+	if len(modules) == 0 || modules==nil {
+		return "pass", nil
+	}
 	modulesStr, err := json.Marshal(modules)
 	if err != nil {
 		fmt.Println("Error marshalling JSON:", err)


### PR DESCRIPTION
The default value of warmup is always false, and cow is always true to keep consistent with the original OL implementation. 

Notice: when memory is limited, warmup might fail. Warmup is still an experimental feature, some of the errors are not carefully handled. Set it to false or enlarge the memory pool if running into any bugs.

I have verified that when downsize the pip-install container to 300MB, warmup would work on 9GB memory on current default cache tree. The reason to downsize the pip-install container is: when the packages in the cache tree are not installed, init containers to install them would consume a lot of memory. If all packages are installed, warming larger cache tree is also possible.