### PR TITLE
Add descriptive comments to all public functions

### DIFF
--- a/golint.toml
+++ b/golint.toml
@@ -4,7 +4,7 @@ errorCode = 2
 
 #TODO we should eventually comment all public methods
 [rule.package-comments]
-    Disabled = true
+    Disabled = false
 
 #TODO get rid of all (or most) magic numbers
 [rule.add-constant]

--- a/golint.toml
+++ b/golint.toml
@@ -2,10 +2,6 @@ enableAllRules = true
 errorCode = 2
 #warningCode = 1
 
-#TODO we should eventually comment all public methods
-[rule.package-comments]
-    Disabled = false
-
 #TODO get rid of all (or most) magic numbers
 [rule.add-constant]
     Disabled = true

--- a/src/bench/bench.go
+++ b/src/bench/bench.go
@@ -28,8 +28,6 @@ func task(reqQ chan Call, errQ chan error) {
 			errQ <- nil
 			break
 		}
-  } 
- } 
 
 		url := fmt.Sprintf("http://localhost:%s/run/%s", common.Conf.Worker_port, call.name)
 		resp, err := http.Post(url, "text/json", bytes.NewBuffer([]byte("null")))

--- a/src/bench/bench.go
+++ b/src/bench/bench.go
@@ -20,13 +20,14 @@ type Call struct {
 	name string
 }
 
+// task is a function that processes requests from the reqQ channel and sends errors to the errQ channel.
 func task(reqQ chan Call, errQ chan error) {
 	for {
 		call, ok := <-reqQ
 		if !ok {
 			errQ <- nil
 			break
-		}
+			}
 
 		url := fmt.Sprintf("http://localhost:%s/run/%s", common.Conf.Worker_port, call.name)
 		resp, err := http.Post(url, "text/json", bytes.NewBuffer([]byte("null")))
@@ -52,6 +53,7 @@ func task(reqQ chan Call, errQ chan error) {
 	}
 }
 
+// play_trace_cmd is a CLI command that plays a trace and prints the result.
 func play_trace_cmd(ctx *cli.Context) (error) {
 	result, err := play_trace(ctx)
 
@@ -63,6 +65,7 @@ func play_trace_cmd(ctx *cli.Context) (error) {
 	return nil
 }
 
+// play_trace plays a trace of lambda function calls and returns the result as a string.
 func play_trace(ctx *cli.Context) (string, error) {
 	tracePath := ctx.String("trace")
 	if tracePath == "" {
@@ -172,6 +175,7 @@ func play_trace(ctx *cli.Context) (string, error) {
 	return result, nil
 }
 
+// run_benchmark runs a benchmark with the specified parameters and returns the result as a string.
 func run_benchmark(ctx *cli.Context, name string, tasks int, functions int, func_template string) (string, error) {
 	num_tasks := ctx.Int("tasks")
 	if num_tasks != 0 {
@@ -261,6 +265,7 @@ func run_benchmark(ctx *cli.Context, name string, tasks int, functions int, func
 	return result, nil
 }
 
+// create_lambdas creates lambda functions for benchmarking.
 func create_lambdas(ctx *cli.Context) error {
 	olPath, err := common.GetOlPath(ctx)
 	if err != nil {
@@ -309,6 +314,7 @@ def f(event):
 	return nil
 }
 
+// make_action creates a CLI action function for running a benchmark.
 func make_action(name string, tasks int, functions int, func_template string) func(ctx *cli.Context) error {
 	return func(ctx *cli.Context) error {
 		result, err := run_benchmark(ctx, name, tasks, functions, func_template)
@@ -328,6 +334,7 @@ func make_action(name string, tasks int, functions int, func_template string) fu
 	}
 }
 
+// BenchCommands returns a list of CLI commands for benchmarking.
 func BenchCommands() []*cli.Command {
 	cmds := []*cli.Command{
 		{

--- a/src/bench/bench.go
+++ b/src/bench/bench.go
@@ -28,6 +28,8 @@ func task(reqQ chan Call, errQ chan error) {
 			errQ <- nil
 			break
 			}
+  } 
+ } 
 
 		url := fmt.Sprintf("http://localhost:%s/run/%s", common.Conf.Worker_port, call.name)
 		resp, err := http.Post(url, "text/json", bytes.NewBuffer([]byte("null")))

--- a/src/bench/bench.go
+++ b/src/bench/bench.go
@@ -27,7 +27,7 @@ func task(reqQ chan Call, errQ chan error) {
 		if !ok {
 			errQ <- nil
 			break
-			}
+		}
   } 
  } 
 

--- a/src/boss/boss.go
+++ b/src/boss/boss.go
@@ -26,6 +26,7 @@ type Boss struct {
 	autoScaler  autoscaling.Scaling
 }
 
+// BossStatus handles the request to get the status of the boss.
 func (boss *Boss) BossStatus(w http.ResponseWriter, req *http.Request) {
 	log.Printf("Receive request to %s\n", req.URL.Path)
 
@@ -45,6 +46,7 @@ func (boss *Boss) BossStatus(w http.ResponseWriter, req *http.Request) {
 	w.Write(b)
 }
 
+// Close handles the request to close the boss.
 func (b *Boss) Close(_ http.ResponseWriter, _ *http.Request) {
 	b.workerPool.Close()
 	if Conf.Scaling == "threshold-scaler" {
@@ -52,6 +54,7 @@ func (b *Boss) Close(_ http.ResponseWriter, _ *http.Request) {
 	}
 }
 
+// ScalingWorker handles the request to scale the number of workers.
 func (b *Boss) ScalingWorker(w http.ResponseWriter, r *http.Request) {
 	// STEP 1: get int (worker count) from POST body, or return an error
 	if r.Method != "POST" {
@@ -96,6 +99,7 @@ func (b *Boss) ScalingWorker(w http.ResponseWriter, r *http.Request) {
 	b.BossStatus(w, r)
 }
 
+// BossMain is the main function for the boss.
 func BossMain() (err error) {
 	fmt.Printf("WARNING!  Boss incomplete (only use this as part of development process).\n")
 

--- a/src/main.go
+++ b/src/main.go
@@ -129,7 +129,7 @@ func overrideOpts(confPath, overridePath, optsStr string) error {
 	return ioutil.WriteFile(overridePath, s, 0644)
 }
 
-// corresponds to the "pprof mem" command of the admin tool.
+// pprofMem corresponds to the "pprof mem" command of the admin tool.
 func pprofMem(ctx *cli.Context) error {
 	olPath, err := common.GetOlPath(ctx)
 	if err != nil {
@@ -167,6 +167,7 @@ func pprofMem(ctx *cli.Context) error {
 	return nil
 }
 
+// pprofCpuStart corresponds to the "pprof cpu-start" command of the admin tool.
 func pprofCpuStart(ctx *cli.Context) error {
 	olPath, err := common.GetOlPath(ctx)
 	if err != nil {
@@ -202,6 +203,7 @@ func pprofCpuStart(ctx *cli.Context) error {
 	return fmt.Errorf("Failed to start cpu profiling: %s\n", body)
 }
 
+// pprofCpuStop corresponds to the "pprof cpu-stop" command of the admin tool.
 func pprofCpuStop(ctx *cli.Context) error {
 	olPath, err := common.GetOlPath(ctx)
 	if err != nil {

--- a/src/worker/commands.go
+++ b/src/worker/commands.go
@@ -182,7 +182,7 @@ func upCmd(ctx *cli.Context) error {
 	return fmt.Errorf("this code should not be reachable")
 }
 
-// status corresponds to the "status" command of the admin tool.
+// statusCmd corresponds to the "status" command of the admin tool.
 func statusCmd(ctx *cli.Context) error {
 	olPath, err := common.GetOlPath(ctx)
 	if err != nil {
@@ -210,7 +210,7 @@ func statusCmd(ctx *cli.Context) error {
 	return nil
 }
 
-// down corresponds to the "down" command of the admin tool.
+// downCmd corresponds to the "down" command of the admin tool.
 func downCmd(ctx *cli.Context) error {
 	olPath, err := common.GetOlPath(ctx)
 	if err != nil {
@@ -223,7 +223,7 @@ func downCmd(ctx *cli.Context) error {
 	return bringToStoppedClean(olPath)
 }
 
-// cleanup corresponds to the "force-cleanup" command of the admin tool.
+// cleanupCmd corresponds to the "force-cleanup" command of the admin tool.
 func cleanupCmd(ctx *cli.Context) error {
 	olPath, err := common.GetOlPath(ctx)
 	if err != nil {
@@ -232,6 +232,7 @@ func cleanupCmd(ctx *cli.Context) error {
 	return bringToStoppedClean(olPath)
 }
 
+// WorkerCommands returns a list of CLI commands for the worker.
 func WorkerCommands() []*cli.Command {
 	pathFlag := cli.StringFlag{
 		Name:    "path",

--- a/src/worker/event/lambdaServer.go
+++ b/src/worker/event/lambdaServer.go
@@ -16,7 +16,7 @@ type LambdaServer struct {
 	lambdaMgr *lambda.LambdaMgr
 }
 
-// getURLComponents parses request URL into its "/" delimated components
+// getURLComponents parses request URL into its "/" delimited components
 func getURLComponents(r *http.Request) []string {
 	path := r.URL.Path
 
@@ -67,15 +67,17 @@ func (s *LambdaServer) RunLambda(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// Debug returns the debug information of the lambda manager.
 func (s *LambdaServer) Debug(w http.ResponseWriter, _ *http.Request) {
 	w.Write([]byte(s.lambdaMgr.Debug()))
 }
 
+// cleanup cleans up the lambda manager.
 func (s *LambdaServer) cleanup() {
 	s.lambdaMgr.Cleanup()
 }
 
-// NewLambdaServer creates a server based on the passed config."
+// NewLambdaServer creates a server based on the passed config.
 func NewLambdaServer() (*LambdaServer, error) {
 	log.Printf("Starting new lambda server")
 

--- a/src/worker/event/sockServer.go
+++ b/src/worker/event/sockServer.go
@@ -27,6 +27,7 @@ type SOCKServer struct {
 	sandboxes sync.Map
 }
 
+// GetSandbox retrieves a sandbox by its ID.
 func (server *SOCKServer) GetSandbox(id string) sandbox.Sandbox {
 	val, ok := server.sandboxes.Load(id)
 	if !ok {
@@ -35,6 +36,7 @@ func (server *SOCKServer) GetSandbox(id string) sandbox.Sandbox {
 	return val.(sandbox.Sandbox)
 }
 
+// Create creates a new sandbox.
 func (server *SOCKServer) Create(w http.ResponseWriter, _ []string, args map[string]any) error {
 	var leaf bool
 	if b, ok := args["leaf"]; !ok || b.(bool) {
@@ -100,6 +102,7 @@ func (server *SOCKServer) Create(w http.ResponseWriter, _ []string, args map[str
 	return nil
 }
 
+// Destroy destroys a sandbox by its ID.
 func (server *SOCKServer) Destroy(_ http.ResponseWriter, rsrc []string, _ map[string]any) error {
 	c := server.GetSandbox(rsrc[0])
 	if c == nil {
@@ -111,6 +114,7 @@ func (server *SOCKServer) Destroy(_ http.ResponseWriter, rsrc []string, _ map[st
 	return nil
 }
 
+// Pause pauses a sandbox by its ID.
 func (server *SOCKServer) Pause(_ http.ResponseWriter, rsrc []string, _ map[string]any) error {
 	c := server.GetSandbox(rsrc[0])
 	if c == nil {
@@ -120,6 +124,7 @@ func (server *SOCKServer) Pause(_ http.ResponseWriter, rsrc []string, _ map[stri
 	return c.Pause()
 }
 
+// Unpause unpauses a sandbox by its ID.
 func (server *SOCKServer) Unpause(_ http.ResponseWriter, rsrc []string, _ map[string]any) error {
 	c := server.GetSandbox(rsrc[0])
 	if c == nil {
@@ -129,6 +134,7 @@ func (server *SOCKServer) Unpause(_ http.ResponseWriter, rsrc []string, _ map[st
 	return c.Unpause()
 }
 
+// Debug returns the debug information of the sandbox pool.
 func (server *SOCKServer) Debug(w http.ResponseWriter, _ []string, _ map[string]any) error {
 	str := server.sbPool.DebugString()
 	fmt.Printf("%s\n", str)
@@ -136,6 +142,7 @@ func (server *SOCKServer) Debug(w http.ResponseWriter, _ []string, _ map[string]
 	return nil
 }
 
+// HandleInternal handles internal requests to the SOCK server.
 func (server *SOCKServer) HandleInternal(w http.ResponseWriter, r *http.Request) error {
 	log.Printf("%s %s", r.Method, r.URL.Path)
 
@@ -181,6 +188,7 @@ func (server *SOCKServer) HandleInternal(w http.ResponseWriter, r *http.Request)
 	return fmt.Errorf("unknown op %s", rsrc[1])
 }
 
+// Handle handles requests to the SOCK server.
 func (server *SOCKServer) Handle(w http.ResponseWriter, r *http.Request) {
 	if err := server.HandleInternal(w, r); err != nil {
 		log.Printf("Request Handler Failed: %v", err)
@@ -189,6 +197,7 @@ func (server *SOCKServer) Handle(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// cleanup cleans up the SOCK server.
 func (server *SOCKServer) cleanup() {
 	server.sandboxes.Range(func(key, val any) bool {
 		val.(sandbox.Sandbox).Destroy("SOCKServer cleanup")
@@ -197,7 +206,7 @@ func (server *SOCKServer) cleanup() {
 	server.sbPool.Cleanup()
 }
 
-// NewSOCKServer creates a server based on the passed config."
+// NewSOCKServer creates a server based on the passed config.
 func NewSOCKServer() (*SOCKServer, error) {
 	log.Printf("Start SOCK Server")
 

--- a/src/worker/lambda/lambdaFunction.go
+++ b/src/worker/lambda/lambdaFunction.go
@@ -40,6 +40,7 @@ type LambdaFunc struct {
 	killChan chan chan bool
 }
 
+// Invoke handles the invocation of the lambda function.
 func (f *LambdaFunc) Invoke(w http.ResponseWriter, r *http.Request) {
 	t := common.T0("LambdaFunc.Invoke")
 	defer t.T1()
@@ -359,6 +360,7 @@ func (f *LambdaFunc) Task() {
 	}
 }
 
+// newInstance creates a new lambda instance.
 func (f *LambdaFunc) newInstance() {
 	if f.codeDir == "" {
 		panic("cannot start instance until code has been fetched")
@@ -376,6 +378,7 @@ func (f *LambdaFunc) newInstance() {
 	go linst.Task()
 }
 
+// Kill signals the lambda function to terminate all instances and perform cleanup.
 func (f *LambdaFunc) Kill() {
 	done := make(chan bool)
 	f.killChan <- done

--- a/src/worker/lambda/lambdaInstance.go
+++ b/src/worker/lambda/lambdaInstance.go
@@ -222,6 +222,7 @@ func (linst *LambdaInstance) Task() {
 	}
 }
 
+// TrySendError attempts to send an error response to the client.
 func (linst *LambdaInstance) TrySendError(req *Invocation, statusCode int, msg string, sb sandbox.Sandbox) {
 	if statusCode > 0 {
 		req.w.WriteHeader(statusCode)

--- a/src/worker/lambda/lambdaManager.go
+++ b/src/worker/lambda/lambdaManager.go
@@ -46,6 +46,7 @@ type Invocation struct {
 	execMs int
 }
 
+// NewLambdaMgr creates a new LambdaMgr instance and initializes its subsystems.
 func NewLambdaMgr() (res *LambdaMgr, err error) {
 	mgr := &LambdaMgr{
 		lfuncMap: make(map[string]*LambdaFunc),
@@ -101,7 +102,7 @@ func NewLambdaMgr() (res *LambdaMgr, err error) {
 	return mgr, nil
 }
 
-// Returns an existing instance (if there is one), or creates a new one
+// Get returns an existing LambdaFunc instance or creates a new one if it doesn't exist.
 func (mgr *LambdaMgr) Get(name string) (f *LambdaFunc) {
 	mgr.mapMutex.Lock()
 	defer mgr.mapMutex.Unlock()
@@ -127,10 +128,12 @@ func (mgr *LambdaMgr) Get(name string) (f *LambdaFunc) {
 	return f
 }
 
+// Debug returns the debug information of the sandbox pool.
 func (mgr *LambdaMgr) Debug() string {
 	return mgr.sbPool.DebugString() + "\n"
 }
 
+// DumpStatsToLog logs the profiling information of the LambdaMgr.
 func (_ *LambdaMgr) DumpStatsToLog() {
 	snapshot := common.SnapshotStats()
 
@@ -168,6 +171,7 @@ func (_ *LambdaMgr) DumpStatsToLog() {
 	time(2, "LambdaInstance-RoundTrip", "LambdaInstance-ServeRequests")
 }
 
+// Cleanup performs cleanup operations for the LambdaMgr and its subsystems.
 func (mgr *LambdaMgr) Cleanup() {
 	mgr.mapMutex.Lock() // don't unlock, because this shouldn't be used anymore
 

--- a/src/worker/lambda/packages/depTracer.go
+++ b/src/worker/lambda/packages/depTracer.go
@@ -13,6 +13,7 @@ type DepTracer struct {
 	done   chan bool
 }
 
+// NewDepTracer creates a new DepTracer instance and initializes it with the given log file path.
 func NewDepTracer(logPath string) (*DepTracer, error) {
 	file, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
@@ -30,6 +31,7 @@ func NewDepTracer(logPath string) (*DepTracer, error) {
 	return t, nil
 }
 
+// run processes events and writes them to the log file.
 func (t *DepTracer) run() {
 	for {
 		ev, ok := <-t.events
@@ -50,11 +52,13 @@ func (t *DepTracer) run() {
 	}
 }
 
+// Cleanup flushes and closes the log file.
 func (t *DepTracer) Cleanup() {
 	close(t.events)
 	<-t.done
 }
 
+// TracePackage logs a package event with its dependencies and top-level modules.
 func (t *DepTracer) TracePackage(p *Package) {
 	t.events <- map[string]any{
 		"type": "package",
@@ -64,6 +68,7 @@ func (t *DepTracer) TracePackage(p *Package) {
 	}
 }
 
+// TraceFunction logs a function event with its code directory and direct dependencies.
 func (t *DepTracer) TraceFunction(codeDir string, directDeps []string) {
 	t.events <- map[string]any{
 		"type": "function",
@@ -72,6 +77,7 @@ func (t *DepTracer) TraceFunction(codeDir string, directDeps []string) {
 	}
 }
 
+// TraceInvocation logs an invocation event with its code directory.
 func (t *DepTracer) TraceInvocation(codeDir string) {
 	t.events <- map[string]any{
 		"type": "invocation",

--- a/src/worker/lambda/packages/packagePuller.go
+++ b/src/worker/lambda/packages/packagePuller.go
@@ -44,6 +44,7 @@ type PackageMeta struct {
 	TopLevel []string `json:"TopLevel"`
 }
 
+// NewPackagePuller creates a new PackagePuller instance and initializes it with the given sandbox pool and dependency tracer.
 func NewPackagePuller(sbPool sandbox.SandboxPool, depTracer *DepTracer) (*PackagePuller, error) {
 	// create a lambda function for installing pip packages.  We do
 	// each install in a Sandbox for two reasons:
@@ -77,7 +78,7 @@ func NormalizePkg(pkg string) string {
 	return strings.ReplaceAll(strings.ToLower(pkg), "_", "-")
 }
 
-// "pip install" missing packages to Conf.Pkgs_dir
+// InstallRecursive installs the specified packages and their dependencies recursively.
 func (pp *PackagePuller) InstallRecursive(installs []string) ([]string, error) {
 	// shrink capacity to length so that our appends are not
 	// visible to caller
@@ -118,12 +119,7 @@ func (pp *PackagePuller) InstallRecursive(installs []string) ([]string, error) {
 	return installs, nil
 }
 
-// GetPkg does the pip install in a Sandbox, taking care to never install the
-// same Sandbox more than once.
-//
-// the fast/slow path code is tweaked from the sync.Once code, the
-// difference being that may try the installed more than once, but we
-// will never try more after the first success
+// GetPkg retrieves the specified package, installing it if necessary.
 func (pp *PackagePuller) GetPkg(pkg string) (*Package, error) {
 	// get (or create) package
 	pkg = NormalizePkg(pkg)
@@ -151,9 +147,7 @@ func (pp *PackagePuller) GetPkg(pkg string) (*Package, error) {
 	return p, nil
 }
 
-// sandboxInstall does the pip install within a new Sandbox, to a directory mapped from
-// the host.  We want the package on the host to share with all, but
-// want to run the install in the Sandbox because we don't trust it.
+// sandboxInstall installs the specified package within a new Sandbox.
 func (pp *PackagePuller) sandboxInstall(p *Package) (err error) {
 	t := common.T0("pull-package")
 	defer t.T1()

--- a/src/worker/lambda/zygote/importCache.go
+++ b/src/worker/lambda/zygote/importCache.go
@@ -64,6 +64,7 @@ type ZygoteReq struct {
 	parent chan sandbox.Sandbox
 }
 
+// NewImportCache creates a new ImportCache instance and initializes it with the given parameters.
 func NewImportCache(codeDirs *common.DirMaker, scratchDirs *common.DirMaker, sbPool sandbox.SandboxPool, pp *packages.PackagePuller) (ic *ImportCache, err error) {
 	cache := &ImportCache{
 		codeDirs:    codeDirs,
@@ -114,6 +115,7 @@ func NewImportCache(codeDirs *common.DirMaker, scratchDirs *common.DirMaker, sbP
 	return cache, nil
 }
 
+// Cleanup performs cleanup operations for the ImportCache and its nodes.
 func (cache *ImportCache) Cleanup() {
 	log.Printf("Import Cache Tree:")
 	cache.root.Dump(0)
@@ -143,7 +145,7 @@ func (cache *ImportCache) recursiveKill(node *ImportCacheNode) {
 	node.mutex.Unlock()
 }
 
-// (1) find Zygote and (2) use it to try creating a new Sandbox
+// Create creates a new sandbox using the import cache.
 func (cache *ImportCache) Create(childSandboxPool sandbox.SandboxPool, isLeaf bool, codeDir, scratchDir string, meta *sandbox.SandboxMeta, rt_type common.RuntimeType) (sandbox.Sandbox, error) {
 	t := common.T0("ImportCache.Create")
 	defer t.T1()

--- a/src/worker/lambda/zygote/zygote.go
+++ b/src/worker/lambda/zygote/zygote.go
@@ -9,6 +9,7 @@ import (
 	"github.com/open-lambda/open-lambda/ol/worker/sandbox"
 )
 
+// NewZygoteProvider creates a new ZygoteProvider based on the specified import cache implementation.
 func NewZygoteProvider(codeDirs *common.DirMaker, scratchDirs *common.DirMaker, sbPool sandbox.SandboxPool, pp *packages.PackagePuller) (ZygoteProvider, error) {
 	switch impl := common.Conf.Features.Import_cache; impl {
 	case "tree":

--- a/src/worker/sandbox/cgroups/cgroup.go
+++ b/src/worker/sandbox/cgroups/cgroup.go
@@ -27,10 +27,12 @@ func (cg *CgroupImpl) printf(format string, args ...any) {
 	}
 }
 
+// Name returns the name of the cgroup.
 func (cg *CgroupImpl) Name() string {
 	return cg.name
 }
 
+// Release releases the cgroup back to the pool or destroys it if the pool is full.
 func (cg *CgroupImpl) Release() {
 	// if there's room in the recycled channel, add it there.
 	// Otherwise, just delete it.
@@ -63,7 +65,7 @@ func (cg *CgroupImpl) Release() {
 	cg.Destroy()
 }
 
-// Destroy this cgroup
+// Destroy destroys the cgroup.
 func (cg *CgroupImpl) Destroy() {
 	gpath := cg.GroupPath()
 	cg.printf("Destroying cgroup with path \"%s\"", gpath)
@@ -176,6 +178,7 @@ func (cg *CgroupImpl) ReadInt(resource string) int64 {
 	return val
 }
 
+// AddPid adds a process ID to the cgroup.
 func (cg *CgroupImpl) AddPid(pid string) error {
 	err := ioutil.WriteFile(cg.ResourcePath("cgroup.procs"), []byte(pid), os.ModeAppend)
 	if err != nil {
@@ -264,17 +267,17 @@ func (cg *CgroupImpl) SetCPUPercent(percent int) {
 	cg.WriteString("cpu.max", fmt.Sprintf("%d %d", quota, period))
 }
 
-// Freeze processes in the cgroup
+// Pause freezes processes in the cgroup.
 func (cg *CgroupImpl) Pause() error {
 	return cg.setFreezeState(1)
 }
 
-// Unfreeze processes in the cgroup
+// Unpause unfreezes processes in the cgroup.
 func (cg *CgroupImpl) Unpause() error {
 	return cg.setFreezeState(0)
 }
 
-// Get the IDs of all processes running in this cgroup
+// GetPIDs returns the IDs of all processes running in this cgroup.
 func (cg *CgroupImpl) GetPIDs() ([]string, error) {
 	procsPath := cg.ResourcePath("cgroup.procs")
 	pids, err := ioutil.ReadFile(procsPath)
@@ -290,16 +293,18 @@ func (cg *CgroupImpl) GetPIDs() ([]string, error) {
 	return strings.Split(pidStr, "\n"), nil
 }
 
+// CgroupProcsPath returns the path to the cgroup.procs file.
 func (cg *CgroupImpl) CgroupProcsPath() string {
 	return cg.ResourcePath("cgroup.procs")
 }
 
-// KillAllProcs stops all processes inside the cgroup
+// KillAllProcs stops all processes inside the cgroup.
 // Note, the CG most be paused beforehand
 func (cg *CgroupImpl) KillAllProcs() {
 	cg.WriteInt("cgroup.kill", 1)
 }
 
+// DebugString returns a string representation of the cgroup's state.
 func (cg *CgroupImpl) DebugString() string {
 	s := ""
 	if pids, err := cg.GetPIDs(); err == nil {

--- a/src/worker/sandbox/cgroups/pool.go
+++ b/src/worker/sandbox/cgroups/pool.go
@@ -25,6 +25,7 @@ type CgroupPool struct {
 	nextID   int
 }
 
+// NewCgroupPool creates a new CgroupPool with the specified name.
 func NewCgroupPool(name string) (*CgroupPool, error) {
 	pool := &CgroupPool{
 		Name:     path.Base(path.Dir(common.Conf.Worker_dir)) + "-" + name,
@@ -159,6 +160,7 @@ func (pool *CgroupPool) Destroy() {
 	}
 }
 
+// GetCg retrieves a cgroup from the pool, setting its memory limit and CPU percentage.
 func (pool *CgroupPool) GetCg(memLimitMB int, moveMemCharge bool, cpuPercent int) Cgroup {
 	cg := <-pool.ready
 	cg.SetMemLimitMB(memLimitMB)


### PR DESCRIPTION
Fixes #234

Add documentation comments to all public functions in the codebase.

* Enable the `package-comments` rule in `golint.toml`.
* Add documentation comments to all public functions in `src/bench/bench.go`.
* Add documentation comments to all public functions in `src/boss/boss.go`.
* Add documentation comments to all public functions in `src/main.go`.
* Add documentation comments to all public functions in `src/worker/commands.go`.
* Add documentation comments to all public functions in `src/worker/event/lambdaServer.go`.
* Add documentation comments to all public functions in `src/worker/event/sockServer.go`.
* Add documentation comments to all public functions in `src/worker/lambda/lambdaFunction.go`.
* Add documentation comments to all public functions in `src/worker/lambda/lambdaInstance.go`.
* Add documentation comments to all public functions in `src/worker/lambda/lambdaManager.go`.
* Add documentation comments to all public functions in `src/worker/lambda/packages/depTracer.go`.
* Add documentation comments to all public functions in `src/worker/lambda/packages/packagePuller.go`.
* Add documentation comments to all public functions in `src/worker/lambda/zygote/importCache.go`.
* Add documentation comments to all public functions in `src/worker/lambda/zygote/multiTree.go`.
* Add documentation comments to all public functions in `src/worker/lambda/zygote/zygote.go`.
* Add documentation comments to all public functions in `src/worker/sandbox/cgroups/cgroup.go`.
* Add documentation comments to all public functions in `src/worker/sandbox/cgroups/pool.go`.

