### PR TITLE
Fix `use cgroup` log message

### DIFF
--- a/src/worker/sandbox/sockPool.go
+++ b/src/worker/sandbox/sockPool.go
@@ -103,7 +103,7 @@ func (pool *SOCKPool) Create(parent Sandbox, isLeaf bool, codeDir, scratchDir st
 	moveMemCharge := (parent == nil)
 	cSock.cg = pool.cgPool.GetCg(meta.MemLimitMB, moveMemCharge, meta.CPUPercent)
 	t2.T1()
-	cSock.printf("use cgroup %s", cSock.cg.Name)
+	cSock.printf("use cgroup %s", cSock.cg.Name())
 
 	defer func() {
 		if err != nil {


### PR DESCRIPTION
This PR fixes a minor bug of a log message.

Before:

```
use cgroup %!s(func() string=0x8e1860) [SOCK 1]
```

After:

```
use cgroup cg-1 [SOCK 1]
```