### PR TITLE
Updated support for Docker sandboxes

### DIFF
--- a/scripts/helper/__init__.py
+++ b/scripts/helper/__init__.py
@@ -254,14 +254,14 @@ class WasmWorker():
         self._process.terminate()
         self._process = None
 
-def prepare_open_lambda(ol_dir):
+def prepare_open_lambda(ol_dir, image="ol-wasm"):
     '''
     Sets up the working director for open lambda,
     and stops currently running worker processes (if any)
     '''
     # init will kill any prior worker and refresh the directory
     # (except for the base "lambda" dir)
-    run(['./ol', 'worker', 'init', f'-p={ol_dir}'])
+    run(['./ol', 'worker', 'init', f'-p={ol_dir}', f'-i={image}'])
 
 def mounts():
     ''' Returns a list of all mounted directories '''

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -7,6 +7,7 @@
 import argparse
 import os
 import tempfile
+import sys
 
 from time import time
 from subprocess import call
@@ -280,6 +281,7 @@ def main():
     parser.add_argument('--test_filter', type=str, default="")
     parser.add_argument('--registry', type=str, default="test-registry")
     parser.add_argument('--ol_dir', type=str, default="test-dir")
+    parser.add_argument('--image', type=str, default="ol-wasm")
 
     args = parser.parse_args()
 
@@ -287,7 +289,7 @@ def main():
     OL_DIR = args.ol_dir
 
     setup_config(args.ol_dir)
-    prepare_open_lambda(args.ol_dir)
+    prepare_open_lambda(args.ol_dir, args.image)
 
     trace_config = {
         "cgroups": True,

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -7,7 +7,6 @@
 import argparse
 import os
 import tempfile
-import sys
 
 from time import time
 from subprocess import call

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -58,6 +58,9 @@ type Config struct {
 	// base image path for sock containers
 	SOCK_base_path string `json:"sock_base_path"`
 
+	// base image tag for docker containers
+	Docker_base_image string `json:"docker_base_image"`
+
 	// pass through to sandbox envirenment variable
 	Sandbox_config any `json:"sandbox_config"`
 
@@ -158,6 +161,7 @@ func LoadDefaults(olPath string) error {
 		Pkgs_dir:          packagesDir,
 		Sandbox_config:    map[string]any{},
 		SOCK_base_path:    baseImgDir,
+		Docker_base_image: "alpine:latest",
 		Registry_cache_ms: 5000, // 5 seconds
 		Mem_pool_mb:       memPoolMb,
 		Import_cache_tree: zygoteTreePath,

--- a/src/worker/helpers.go
+++ b/src/worker/helpers.go
@@ -73,6 +73,23 @@ func initOLBaseDir(baseDir string, dockerBaseImage string) error {
 
 	path = filepath.Join(baseDir, "dev", "urandom")
 
+	// PART 4: pull the docker base image only if not available
+	imageFilter := map[string][]string{
+		"reference": {common.Conf.Docker_base_image},
+	}
+	images, err := dockerClient.ListImages(docker.ListImagesOptions{
+		Filters: imageFilter,
+	})
+	if err != nil {
+		return err
+	}
+	if len(images) == 0 {
+		err = dockerClient.PullImage(docker.PullImageOptions{Repository: common.Conf.Docker_base_image}, docker.AuthConfiguration{})
+		if err != nil {
+			return err
+		}
+	}
+
 	return exec.Command("mknod", "-m", "0644", path, "c", "1", "9").Run()
 }
 

--- a/src/worker/helpers.go
+++ b/src/worker/helpers.go
@@ -73,20 +73,22 @@ func initOLBaseDir(baseDir string, dockerBaseImage string) error {
 
 	path = filepath.Join(baseDir, "dev", "urandom")
 
-	// PART 4: pull the docker base image only if not available
-	imageFilter := map[string][]string{
-		"reference": {common.Conf.Docker_base_image},
-	}
-	images, err := dockerClient.ListImages(docker.ListImagesOptions{
-		Filters: imageFilter,
-	})
-	if err != nil {
-		return err
-	}
-	if len(images) == 0 {
-		err = dockerClient.PullImage(docker.PullImageOptions{Repository: common.Conf.Docker_base_image}, docker.AuthConfiguration{})
+	// PART 4: pull the docker base image if using docker sandbox
+	if common.Conf.Sandbox == "docker" {
+		imageFilter := map[string][]string{
+			"reference": {common.Conf.Docker_base_image},
+		}
+		images, err := dockerClient.ListImages(docker.ListImagesOptions{
+			Filters: imageFilter,
+		})
 		if err != nil {
 			return err
+		}
+		if len(images) == 0 {
+			err = dockerClient.PullImage(docker.PullImageOptions{Repository: common.Conf.Docker_base_image}, docker.AuthConfiguration{})
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Summary:
This pull request mainly changes the way in which Docker containers are created for use as sandboxes. Additionally, minor changes were made to the tester script to allow for the use of other base images besides ol-min when testing.

Key Changes:
- src/worker/sandbox/dockerPool.go: changed container created logic by adding directory binds and container configuration settings
- min-image/runtimes/python/server_legacy.py: copied tornado app creation logic from server.py to support flask in Docker sandboxes
- scripts/test.py: added support for testing with base images other than ol-min

Known Issues/Concerns:
- There might be an issue with unwanted accumulation of Docker overlay2 filesystems on the machine running OL. The Docker daemon might not be cleaning up the system correctly.
- Docker sometimes uses more memory overhead (17 MB) than the maximum expected overhead from the max_mem_alloc test (16 MB).
- Currently, parsing the difference between package installer sandboxes and lambda sandboxes relies on a hard-coded check of the scratch directory path. This may need to be changed to ensure correct memory limits on these two types of sandboxes.
