### PR TITLE
Updated support for Docker sandboxes V2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         make sudo-install
     - name: Test Python (Docker)
       # not all features are supported by docker yet, so we only run some of the tests
-      run: sudo env "PATH=$PATH" ./scripts/test.py --worker_type=docker --test_filter=ping_test,numpy
+      run: sudo env "PATH=$PATH" ./scripts/test.py --worker_type=docker --test_blocklist=max_mem_alloc
     - name: Test Python (SOCK)
       run: sudo env "PATH=$PATH" ./scripts/test.py --worker_type=sock
       timeout-minutes: 20

--- a/Makefile
+++ b/Makefile
@@ -82,11 +82,11 @@ sudo-install: build
 	sudo cp ol-container-proxy ${INSTALL_PREFIX}/bin/
 
 test-all:
-	python3 -u ./scripts/test.py --worker_type=sock
-	python3 -u ./scripts/test.py --worker_type=docker --test_filter=ping_test,numpy
-	python3 -u ./scripts/sock_test.py
-	python3 -u ./scripts/bin_test.py --worker_type=wasm
-	python3 -u ./scripts/bin_test.py --worker_type=sock
+	sudo python3 -u ./scripts/test.py --worker_type=sock
+	sudo python3 -u ./scripts/test.py --worker_type=docker --test_blocklist=max_mem_alloc
+	sudo python3 -u ./scripts/sock_test.py
+	sudo python3 -u ./scripts/bin_test.py --worker_type=wasm
+	sudo python3 -u ./scripts/bin_test.py --worker_type=sock
 
 fmt:
 	#cd src && go fmt ...

--- a/scripts/helper/__init__.py
+++ b/scripts/helper/__init__.py
@@ -255,16 +255,14 @@ class WasmWorker():
         self._process.terminate()
         self._process = None
 
-
-def prepare_open_lambda(ol_dir):
+def prepare_open_lambda(ol_dir, image="ol-wasm"):
     '''
     Sets up the working director for open lambda,
     and stops currently running worker processes (if any)
     '''
     # init will kill any prior worker and refresh the directory
     # (except for the base "lambda" dir)
-    run(['./ol', 'worker', 'init', f'-p={ol_dir}'])
-
+    run(['./ol', 'worker', 'init', f'-p={ol_dir}', f'-i={image}'])
 
 def mounts():
     ''' Returns a list of all mounted directories '''

--- a/scripts/helper/test.py
+++ b/scripts/helper/test.py
@@ -13,6 +13,7 @@ import traceback
 from . import ol_oom_killer, mounts, get_ol_stats, get_current_config, get_worker_output
 
 TEST_FILTER = []
+TEST_BLOCKLIST = []
 WORKER_TYPE = []
 RESULTS = OrderedDict({"runs": []})
 START_TIME = None
@@ -27,6 +28,12 @@ def set_test_filter(new_val):
 
     global TEST_FILTER
     TEST_FILTER = new_val
+
+def set_test_blocklist(new_val):
+    ''' Sets up the blocklist for all following tests '''
+
+    global TEST_BLOCKLIST
+    TEST_BLOCKLIST = new_val
 
 def start_tests():
     ''' Starts the background logic for a test run '''
@@ -60,6 +67,9 @@ def check_test_results():
     sys.exit(failed)
 
 def _test_in_filter(name):
+    if name in TEST_BLOCKLIST:
+        return False
+
     if len(TEST_FILTER) == 0:
         return True
 

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -17,7 +17,14 @@ import requests
 from helper import DockerWorker, SockWorker, prepare_open_lambda, setup_config
 from helper import get_current_config, TestConfContext, assert_eq
 
-from helper.test import set_test_filter, set_test_blocklist, start_tests, check_test_results, set_worker_type, test
+from helper.test import (
+    set_test_filter,
+    set_test_blocklist,
+    start_tests,
+    check_test_results,
+    set_worker_type,
+    test
+)
 
 from open_lambda import OpenLambda
 
@@ -289,12 +296,12 @@ def main():
     args = parser.parse_args()
 
     if args.test_filter and args.test_blocklist:
-        raise RuntimeError(f"--test_filter and --test_blocklist cannot be used together")
-    elif args.test_filter:
+        raise RuntimeError("--test_filter and --test_blocklist cannot be used together")
+    if args.test_filter:
         set_test_filter([name for name in args.test_filter.split(",") if name != ''])
     elif args.test_blocklist:
         set_test_blocklist([name for name in args.test_blocklist.split(",") if name != ''])
-    
+
     OL_DIR = args.ol_dir
 
     setup_config(args.ol_dir)

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -17,7 +17,7 @@ import requests
 from helper import DockerWorker, SockWorker, prepare_open_lambda, setup_config
 from helper import get_current_config, TestConfContext, assert_eq
 
-from helper.test import set_test_filter, start_tests, check_test_results, set_worker_type, test
+from helper.test import set_test_filter, set_test_blocklist, start_tests, check_test_results, set_worker_type, test
 
 from open_lambda import OpenLambda
 
@@ -281,16 +281,24 @@ def main():
     parser = argparse.ArgumentParser(description='Run tests for OpenLambda')
     parser.add_argument('--worker_type', type=str, default="sock")
     parser.add_argument('--test_filter', type=str, default="")
+    parser.add_argument('--test_blocklist', type=str, default="")
     parser.add_argument('--registry', type=str, default="test-registry")
     parser.add_argument('--ol_dir', type=str, default="test-dir")
+    parser.add_argument('--image', type=str, default="ol-wasm")
 
     args = parser.parse_args()
 
-    set_test_filter([name for name in args.test_filter.split(",") if name != ''])
+    if args.test_filter and args.test_blocklist:
+        raise RuntimeError(f"--test_filter and --test_blocklist cannot be used together")
+    elif args.test_filter:
+        set_test_filter([name for name in args.test_filter.split(",") if name != ''])
+    elif args.test_blocklist:
+        set_test_blocklist([name for name in args.test_blocklist.split(",") if name != ''])
+    
     OL_DIR = args.ol_dir
 
     setup_config(args.ol_dir)
-    prepare_open_lambda(args.ol_dir)
+    prepare_open_lambda(args.ol_dir, args.image)
 
     trace_config = {
         "cgroups": True,

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -64,6 +64,9 @@ type Config struct {
 	// which OCI implementation to use for the docker sandbox (e.g., runc or runsc)
 	Docker_runtime string `json:"docker_runtime"`
 
+	// name of the image used for Docker containers
+	Docker_base_image string `json:"docker_base_image"`
+
 	Limits   LimitsConfig   `json:"limits"`
 	Features FeaturesConfig `json:"features"`
 	Trace    TraceConfig    `json:"trace"`
@@ -131,7 +134,7 @@ type LimitsConfig struct {
 
 // Choose reasonable defaults for a worker deployment (based on memory capacity).
 // olPath need not exist (it is used to determine default paths for registry, etc).
-func LoadDefaults(olPath string) error {
+func LoadDefaults(olPath string, dockerImg string) error {
 	workerDir := filepath.Join(olPath, "worker")
 	registryDir := filepath.Join(olPath, "registry")
 	baseImgDir := filepath.Join(olPath, "lambda")
@@ -161,6 +164,7 @@ func LoadDefaults(olPath string) error {
 		Registry_cache_ms: 5000, // 5 seconds
 		Mem_pool_mb:       memPoolMb,
 		Import_cache_tree: zygoteTreePath,
+		Docker_base_image: dockerImg,
 		Limits: LimitsConfig{
 			Procs:               10,
 			Mem_mb:              50,

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -61,16 +61,18 @@ type Config struct {
 	// pass through to sandbox envirenment variable
 	Sandbox_config any `json:"sandbox_config"`
 
-	// which OCI implementation to use for the docker sandbox (e.g., runc or runsc)
-	Docker_runtime string `json:"docker_runtime"`
-
-	// name of the image used for Docker containers
-	Docker_base_image string `json:"docker_base_image"`
-
+	Docker   DockerConfig   `json:"docker"`
 	Limits   LimitsConfig   `json:"limits"`
 	Features FeaturesConfig `json:"features"`
 	Trace    TraceConfig    `json:"trace"`
 	Storage  StorageConfig  `json:"storage"`
+}
+
+type DockerConfig struct {
+	// which OCI implementation to use for the docker sandbox (e.g., runc or runsc)
+	Runtime string `json:"runtime"`
+	// name of the image used for Docker containers
+	Base_image string `json:"base_image"`
 }
 
 type FeaturesConfig struct {
@@ -134,7 +136,7 @@ type LimitsConfig struct {
 
 // Choose reasonable defaults for a worker deployment (based on memory capacity).
 // olPath need not exist (it is used to determine default paths for registry, etc).
-func LoadDefaults(olPath string, dockerImg string) error {
+func LoadDefaults(olPath string) error {
 	workerDir := filepath.Join(olPath, "worker")
 	registryDir := filepath.Join(olPath, "registry")
 	baseImgDir := filepath.Join(olPath, "lambda")
@@ -164,7 +166,9 @@ func LoadDefaults(olPath string, dockerImg string) error {
 		Registry_cache_ms: 5000, // 5 seconds
 		Mem_pool_mb:       memPoolMb,
 		Import_cache_tree: zygoteTreePath,
-		Docker_base_image: dockerImg,
+		Docker: DockerConfig{
+			Base_image: "ol-min",
+		}
 		Limits: LimitsConfig{
 			Procs:               10,
 			Mem_mb:              50,

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -168,7 +168,7 @@ func LoadDefaults(olPath string) error {
 		Import_cache_tree: zygoteTreePath,
 		Docker: DockerConfig{
 			Base_image: "ol-min",
-		}
+		},
 		Limits: LimitsConfig{
 			Procs:               10,
 			Mem_mb:              50,

--- a/src/worker/commands.go
+++ b/src/worker/commands.go
@@ -25,7 +25,7 @@ func initCmd(ctx *cli.Context) error {
 		return err
 	}
 
-	if err := common.LoadDefaults(olPath); err != nil {
+	if err := common.LoadDefaults(olPath, ctx.String("image")); err != nil {
 		return err
 	}
 
@@ -50,7 +50,7 @@ func upCmd(ctx *cli.Context) error {
 	if _, err := os.Stat(olPath); os.IsNotExist(err) {
 		// need to init worker dir first
 		fmt.Printf("Did not find OL directory at %s\n", olPath)
-		if err := common.LoadDefaults(olPath); err != nil {
+		if err := common.LoadDefaults(olPath, ctx.String("image")); err != nil {
 			return err
 		}
 

--- a/src/worker/commands.go
+++ b/src/worker/commands.go
@@ -25,7 +25,7 @@ func initCmd(ctx *cli.Context) error {
 		return err
 	}
 
-	if err := common.LoadDefaults(olPath, ctx.String("image")); err != nil {
+	if err := common.LoadDefaults(olPath); err != nil {
 		return err
 	}
 
@@ -50,7 +50,7 @@ func upCmd(ctx *cli.Context) error {
 	if _, err := os.Stat(olPath); os.IsNotExist(err) {
 		// need to init worker dir first
 		fmt.Printf("Did not find OL directory at %s\n", olPath)
-		if err := common.LoadDefaults(olPath, ctx.String("image")); err != nil {
+		if err := common.LoadDefaults(olPath); err != nil {
 			return err
 		}
 

--- a/src/worker/sandbox/dockerPool.go
+++ b/src/worker/sandbox/dockerPool.go
@@ -50,7 +50,7 @@ func NewDockerPool(pidMode string, caps []string) (*DockerPool, error) {
 		pidMode:       pidMode,
 		pkgsDir:       common.Conf.Pkgs_dir,
 		idxPtr:        idxPtr,
-		dockerRuntime: common.Conf.Docker_runtime,
+		dockerRuntime: common.Conf.Docker.Runtime,
 		eventHandlers: []SandboxEventFunc{},
 	}
 
@@ -109,17 +109,11 @@ func (pool *DockerPool) Create(parent Sandbox, isLeaf bool, codeDir, scratchDir 
 	procLimit := int64(common.Conf.Limits.Procs)
 	swappiness := int64(common.Conf.Limits.Swappiness)
 	cpuPercent := int64(common.Conf.Limits.CPU_percent)
-	var memoryLimit int64
-	if strings.Contains(scratchDir, "scratch") {
-		memoryLimit = int64(common.Conf.Limits.Mem_mb * 1024 * 1024)
-	} else {
-		memoryLimit = int64(common.Conf.Limits.Installer_mem_mb * 1024 * 1024)
-	}
 	container, err := pool.client.CreateContainer(
 		docker.CreateContainerOptions{
 			Config: &docker.Config{
 				Cmd:    []string{"/spin"},
-				Image:  common.Conf.Docker_base_image,
+				Image:  common.Conf.Docker.Base_image,
 				Labels: pool.labels,
 				Env:    []string{"PYTHONPATH=" + strings.Join(pkgDirs, ":")},
 			},
@@ -131,7 +125,7 @@ func (pool *DockerPool) Create(parent Sandbox, isLeaf bool, codeDir, scratchDir 
 				PidsLimit:        &procLimit,
 				MemorySwappiness: &swappiness,
 				CPUPercent:       cpuPercent,
-				Memory:           memoryLimit,
+				Memory:           meta.MemLimitMB,
 			},
 		},
 	)

--- a/src/worker/sandbox/dockerPool.go
+++ b/src/worker/sandbox/dockerPool.go
@@ -125,7 +125,7 @@ func (pool *DockerPool) Create(parent Sandbox, isLeaf bool, codeDir, scratchDir 
 				PidsLimit:        &procLimit,
 				MemorySwappiness: &swappiness,
 				CPUPercent:       cpuPercent,
-				Memory:           meta.MemLimitMB,
+				Memory:           int64(meta.MemLimitMB * 1024 * 1024),
 			},
 		},
 	)


### PR DESCRIPTION
This pull request is a rewrite of #262. The primary change is that dockerPool.go now creates containers directly from the original Docker image rather than relying on directory binds on the flattened image. Additionally, this PR adds more changes to testing and CI workflows to better support Docker. The three concerns outlined in PR #262 remain unresolved.