### PR TITLE
Prevent segfault during `ol worker force-cleanup`

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -225,8 +225,8 @@ func pprofCpuStop(ctx *cli.Context) error {
 	if response.StatusCode == 400 {
 		return fmt.Errorf("Should call \"ol pprof cpu-start\" first\n")
 	} else if response.StatusCode == 500 {
-   	 	return fmt.Errorf("Unknown server error\n")
-  	}
+		return fmt.Errorf("Unknown server error\n")
+	}
 
 	path := ctx.String("out")
 	if path == "" {
@@ -374,17 +374,17 @@ OPTIONS:
 					Name:      "cpu-start",
 					Usage:     "Starts CPU profiling",
 					UsageText: "ol pprof cpu-start ",
-					Action: pprofCpuStart,
+					Action:    pprofCpuStart,
 				},
 				{
 					Name:      "cpu-stop",
 					Usage:     "Stops CPU profiling if started",
 					UsageText: "ol pprof cpu-stop [--out=NAME]",
-					Action: pprofCpuStop,
+					Action:    pprofCpuStop,
 					Flags: []cli.Flag{
 						&cli.StringFlag{
-							Name: "out",
-              Aliases: []string{"o"},
+							Name:    "out",
+							Aliases: []string{"o"},
 						},
 					},
 				},

--- a/src/worker/commands.go
+++ b/src/worker/commands.go
@@ -229,6 +229,10 @@ func cleanupCmd(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+  	err = common.LoadConf(filepath.Join(olPath, "config.json"))
+	if err != nil {
+		return fmt.Errorf("failed to load OL config: %s", err)
+	}
 	return bringToStoppedClean(olPath)
 }
 

--- a/src/worker/helpers.go
+++ b/src/worker/helpers.go
@@ -186,6 +186,9 @@ const (
 // This function returns the current state of OpenLambda, the PID if possible,
 // and an error if it encounters any.
 func checkState() (OlState, error) {
+    if common.Conf == nil {
+        panic("Invalid state: config not initialized");
+    }
 
 	olPath := common.Conf.Worker_dir
 	dirStat, err := os.Stat(olPath)
@@ -396,11 +399,6 @@ func stoppedDirtyToStoppedClean(olPath string) error {
 
 // bringToStoppedClean tries the best to bring the state of OpenLambda to StoppedClean no mater which state it is in.
 func bringToStoppedClean(olPath string) error {
-	err := common.LoadConf(filepath.Join(olPath, "config.json"))
-	if err != nil {
-		return fmt.Errorf("failed to load OL config: %s", err)
-	}
-
 	state, err := checkState()
 	if err != nil {
 		return fmt.Errorf("failed to check OL state: %s", err)

--- a/src/worker/helpers.go
+++ b/src/worker/helpers.go
@@ -186,9 +186,9 @@ const (
 // This function returns the current state of OpenLambda, the PID if possible,
 // and an error if it encounters any.
 func checkState() (OlState, error) {
-    if common.Conf == nil {
-        panic("Invalid state: config not initialized");
-    }
+	if common.Conf == nil {
+		panic("Invalid state: config not initialized");
+	}
 
 	olPath := common.Conf.Worker_dir
 	dirStat, err := os.Stat(olPath)

--- a/src/worker/helpers.go
+++ b/src/worker/helpers.go
@@ -186,6 +186,7 @@ const (
 // This function returns the current state of OpenLambda, the PID if possible,
 // and an error if it encounters any.
 func checkState() (OlState, error) {
+
 	olPath := common.Conf.Worker_dir
 	dirStat, err := os.Stat(olPath)
 	if os.IsNotExist(err) {
@@ -395,6 +396,11 @@ func stoppedDirtyToStoppedClean(olPath string) error {
 
 // bringToStoppedClean tries the best to bring the state of OpenLambda to StoppedClean no mater which state it is in.
 func bringToStoppedClean(olPath string) error {
+	err := common.LoadConf(filepath.Join(olPath, "config.json"))
+	if err != nil {
+		return fmt.Errorf("failed to load OL config: %s", err)
+	}
+
 	state, err := checkState()
 	if err != nil {
 		return fmt.Errorf("failed to check OL state: %s", err)


### PR DESCRIPTION
It seems like OL does not load the configuration before using it when calling force-cleanup and segfaults on a nullpointer dereference.

I added a test for Conf being null to checkStatus as well, which is where the segfault happened for me. It is probably not the best idea to have common.Conf as a global variable that can be uninitialized, but changing that is a lot of work.

Finally, I ran `go fmt` which also fixed some other formatting issues.

Maybe @tylerharter or @nannoda can let me know if this looks okay? 