### PR TITLE
adding per-lambda memory limit files

### DIFF
--- a/src/common/lambdaConfig.go
+++ b/src/common/lambdaConfig.go
@@ -37,7 +37,8 @@ type CronTrigger struct {
 
 // LambdaConfig defines the overall configuration for the lambda function.
 type LambdaConfig struct {
-	Triggers Triggers `yaml:"triggers"` // List of HTTP triggers
+	Triggers    Triggers `yaml:"triggers"`
+	MemoryMaxMB int      `yaml:"memory_mb,omitempty"` // List of HTTP triggers
 	// Additional configurations can be added here.
 }
 

--- a/src/worker/sandbox/sockPool.go
+++ b/src/worker/sandbox/sockPool.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net"
+	"net/http"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
-	"net"
-	"net/http"
 	"time"
 
 	"github.com/open-lambda/open-lambda/ol/common"
@@ -101,7 +101,21 @@ func (pool *SOCKPool) Create(parent Sandbox, isLeaf bool, codeDir, scratchDir st
 	// don't want to use this cgroup feature, because the child
 	// would take the blame for ALL of the parent's allocations
 	moveMemCharge := (parent == nil)
-	cSock.cg = pool.cgPool.GetCg(meta.MemLimitMB, moveMemCharge, meta.CPUPercent)
+	// load lambda-specific config from code directory
+	lambdaConfig, err := common.LoadLambdaConfig(codeDir)
+	if err != nil {
+		// log error and use default settings
+		pool.printf("could not load lambda config from %s: %v. proceeding with defaults.", codeDir, err)
+	}
+	// start with default memory limit
+	memLimitMB := meta.MemLimitMB
+	// override default if config gives a value
+	if lambdaConfig != nil && lambdaConfig.MemoryMaxMB > 0 {
+		memLimitMB = lambdaConfig.MemoryMaxMB
+		// log memory override
+		pool.printf("using per-lambda memory limit of %d mb", memLimitMB)
+	}
+	cSock.cg = pool.cgPool.GetCg(memLimitMB, moveMemCharge, meta.CPUPercent)
 	t2.T1()
 	cSock.printf("use cgroup %s", cSock.cg.Name())
 
@@ -192,7 +206,7 @@ func (pool *SOCKPool) Create(parent Sandbox, isLeaf bool, codeDir, scratchDir st
 
 	cSock.client = &http.Client{
 		Transport: &http.Transport{Dial: dial},
-		Timeout: time.Second * time.Duration(common.Conf.Limits.Max_runtime_default),
+		Timeout:   time.Second * time.Duration(common.Conf.Limits.Max_runtime_default),
 	}
 
 	// event handling


### PR DESCRIPTION
I've tried implementing per-lambda memory limits. This would allow a function to define its own memory limit via a memory_mb key in its ol.yaml file.

My changes are:
- I added a MemoryMaxMB field to the LambdaConfig struct in src/common/lambdaConfig.go.
- I updated the sandbox creation logic in src/worker/sandbox/sockPool.go to use this new value. If a per-lambda limit isn't set, it falls back to the global default as expected.