### PR TITLE
fix: update fmt.Errorf/Printf usage to resolve format string errors

### DIFF
--- a/go/boss/cloudvm/azure.go
+++ b/go/boss/cloudvm/azure.go
@@ -100,7 +100,7 @@ func Download() {
 
 func Delete() {
 	// Delete the blob
-	fmt.Printf("Deleting the blob " + blobName + "\n")
+	fmt.Printf("Deleting the blob %s\n", blobName)
 
 	_, err = blobClient.Delete(ctx, nil)
 	if err != nil {
@@ -109,7 +109,7 @@ func Delete() {
 	}
 
 	// Delete the container
-	fmt.Printf("Deleting the blob " + containerName + "\n")
+	fmt.Printf("Deleting the blob %s\n", containerName)
 	_, err = containerClient.Delete(ctx, nil)
 
 	if err != nil {
@@ -220,7 +220,7 @@ func AzureMain(contents string) {
 	fmt.Printf("Cleaning up.\n")
 
 	// Delete the blob
-	fmt.Printf("Deleting the blob " + blobName + "\n")
+	fmt.Printf("Deleting the blob %s\n", blobName)
 
 	_, err = blobClient.Delete(ctx, nil)
 	if err != nil {
@@ -229,7 +229,7 @@ func AzureMain(contents string) {
 	}
 
 	// Delete the container
-	fmt.Printf("Deleting the blob " + containerName + "\n")
+	fmt.Printf("Deleting the blob %s\n", containerName)
 	_, err = containerClient.Delete(ctx, nil)
 
 	if err != nil {

--- a/go/worker/lambda/lambdaInstance.go
+++ b/go/worker/lambda/lambdaInstance.go
@@ -162,7 +162,7 @@ func (linst *LambdaInstance) Task() {
 					if _, err := io.Copy(req.w, resp.Body); err != nil {
 						// already used WriteHeader, so can't use that to surface on error anymore
 						msg := "reading lambda response failed: " + err.Error() + "\n"
-						f.printf("error: " + msg)
+						f.printf("error: %s", msg)
 						linst.TrySendError(req, 0, msg, sb)
 					}
 

--- a/go/worker/sandbox/cgroups/cgroup.go
+++ b/go/worker/sandbox/cgroups/cgroup.go
@@ -327,7 +327,7 @@ func (cg *CgroupImpl) DebugString() string {
 	if kills, err := cg.TryReadIntKV("memory.events", "oom_kill"); err == nil {
 		s += fmt.Sprintf("OOM KILLS: %d\n", kills)
 	} else {
-		s += fmt.Sprintf("OOM KILLS: could not read because %d\n", err.Error())
+		s += fmt.Sprintf("OOM KILLS: could not read because %v\n", err)
 	}
 	return s
 }

--- a/go/worker/sandbox/dockerutil/dockerutil.go
+++ b/go/worker/sandbox/dockerutil/dockerutil.go
@@ -30,7 +30,7 @@ func ImageExists(client *docker.Client, name string) (bool, error) {
 func SafeKill(client *docker.Client, cid string) error {
 	container_insp, err := client.InspectContainer(cid)
 	if err != nil {
-		return fmt.Errorf("failed to get inspect docker container ID %v: ", cid, err)
+		return fmt.Errorf("failed to get inspect docker container ID %v: %v", cid, err)
 	}
 
 	if container_insp.State.Dead {
@@ -41,14 +41,14 @@ func SafeKill(client *docker.Client, cid string) error {
 	if container_insp.State.Paused {
 		fmt.Printf("Unpause container %v\n", cid)
 		if err := client.UnpauseContainer(cid); err != nil {
-			return fmt.Errorf("failed to unpause container %v.  May require manual cleanup: ", cid, err)
+			return fmt.Errorf("failed to unpause container %v.  May require manual cleanup: %v", cid, err)
 		}
 	}
 
 	fmt.Printf("Kill container %v\n", cid)
 	killopts := docker.KillContainerOptions{ID: cid}
 	if err := client.KillContainer(killopts); err != nil {
-		return fmt.Errorf("failed to kill container %v.  May require manual cleanup: ", cid, err)
+		return fmt.Errorf("failed to kill container %v.  May require manual cleanup: %v", cid, err)
 	}
 
 	return nil
@@ -63,7 +63,7 @@ func SafeRemove(client *docker.Client, cid string) error {
 	fmt.Printf("Remove container %v\n", cid)
 	rmopts := docker.RemoveContainerOptions{ID: cid}
 	if err := client.RemoveContainer(rmopts); err != nil {
-		return fmt.Errorf("failed to remove container %v.  May require manual cleanup: ", cid, err)
+		return fmt.Errorf("failed to remove container %v.  May require manual cleanup: %v", cid, err)
 	}
 
 	return nil

--- a/go/worker/sandbox/evictors.go
+++ b/go/worker/sandbox/evictors.go
@@ -133,7 +133,7 @@ func (evictor *SOCKEvictor) updateState() {
 		switch event.EvType {
 		case EvCreate:
 			if prio != 0 {
-				panic(fmt.Sprintf("Sandboxes should be at prio 0 upon EvCreate event but it was %d for %d", prio, sb.ID()))
+				panic(fmt.Sprintf("Sandboxes should be at prio 0 upon EvCreate event but it was %d for %s", prio, sb.ID()))
 			}
 			prio += 1
 		case EvUnpause:
@@ -151,7 +151,7 @@ func (evictor *SOCKEvictor) updateState() {
 
 		evictor.printf("Evictor: Sandbox %v priority goes to %d", sb.ID(), prio)
 		if prio < 0 {
-			panic(fmt.Sprintf("priority should never go negative, but it went to %d for sandbox %d", prio, sb.ID()))
+			panic(fmt.Sprintf("priority should never go negative, but it went to %d for sandbox %s", prio, sb.ID()))
 			panic("priority should never go negative")
 		}
 


### PR DESCRIPTION
Updated usage of `fmt.Errorf` and `fmt.Printf` in the `go/` directory to resolve compilation issues.