### PR TITLE
Added worker specific kafka config

### DIFF
--- a/go/common/config.go
+++ b/go/common/config.go
@@ -68,6 +68,20 @@ type Config struct {
 	Features        FeaturesConfig `json:"features"`
 	Trace           TraceConfig    `json:"trace"`
 	Storage         StorageConfig  `json:"storage"`
+	Kafka           KafkaConfig    `json:"kafka"`
+}
+
+type KafkaConfig struct {
+	// whether to enable the LRU message cache for seek-based replay
+	Cache_enabled bool `json:"cache_enabled"`
+	// maximum number of records held in the LRU cache
+	Cache_size int `json:"cache_size"`
+	// Kafka consumer session timeout in seconds
+	Session_timeout_sec int `json:"session_timeout_sec"`
+	// Kafka consumer heartbeat interval in seconds
+	Heartbeat_interval_sec int `json:"heartbeat_interval_sec"`
+	// poll timeout in seconds for each PollFetches call
+	Poll_timeout_sec int `json:"poll_timeout_sec"`
 }
 
 type DockerConfig struct {
@@ -315,6 +329,13 @@ func getDefaultConfigForPatching(olPath string) (*Config, error) {
 			Root:    "private",
 			Scratch: "",
 			Code:    "",
+		},
+		Kafka: KafkaConfig{
+			Cache_enabled:          true,
+			Cache_size:             1024,
+			Session_timeout_sec:    10,
+			Heartbeat_interval_sec: 3,
+			Poll_timeout_sec:       1,
 		},
 	}
 

--- a/go/worker/event/cachedKafkaClient.go
+++ b/go/worker/event/cachedKafkaClient.go
@@ -26,8 +26,6 @@ type seekRequest struct {
 	offset int64
 }
 
-const defaultCacheSize = 1024
-
 // cachedKafkaClient wraps a KafkaClient and caches records in an LRU map keyed
 // by {topic, partition, offset}. When a seek is active, PollFetches serves
 // records from the cache. On cache miss, it calls Seek on the underlying

--- a/go/worker/event/kafkaServer.go
+++ b/go/worker/event/kafkaServer.go
@@ -89,13 +89,15 @@ func (km *KafkaManager) newLambdaKafkaConsumer(consumerName string, lambdaName s
 		return nil, fmt.Errorf("no topics configured for lambda %s", lambdaName)
 	}
 
+	kafkaCfg := common.Conf.Kafka
+
 	// Setup kgo client options
 	opts := []kgo.Opt{
 		kgo.SeedBrokers(trigger.BootstrapServers...),
 		kgo.ConsumerGroup(trigger.GroupId),
 		kgo.ConsumeTopics(trigger.Topics...),
-		kgo.SessionTimeout(10 * time.Second),
-		kgo.HeartbeatInterval(3 * time.Second),
+		kgo.SessionTimeout(time.Duration(kafkaCfg.Session_timeout_sec) * time.Second),
+		kgo.HeartbeatInterval(time.Duration(kafkaCfg.Heartbeat_interval_sec) * time.Second),
 	}
 
 	// Use trigger-specific offset reset or default to latest
@@ -111,12 +113,15 @@ func (km *KafkaManager) newLambdaKafkaConsumer(consumerName string, lambdaName s
 		return nil, fmt.Errorf("failed to create Kafka client for lambda %s: %w", lambdaName, err)
 	}
 
-	cached := newCachedKafkaClient(&kgoClientWrapper{client: client}, defaultCacheSize)
+	var kafkaClient KafkaClient = &kgoClientWrapper{client: client}
+	if kafkaCfg.Cache_enabled {
+		kafkaClient = newCachedKafkaClient(kafkaClient, kafkaCfg.Cache_size)
+	}
 	return &LambdaKafkaConsumer{
 		consumerName: consumerName,
 		lambdaName:   lambdaName,
 		kafkaTrigger: trigger,
-		client:       cached,
+		client:       kafkaClient,
 		invoker:      km.invoker,
 		stopChan:     make(chan struct{}),
 	}, nil
@@ -154,7 +159,7 @@ func (lkc *LambdaKafkaConsumer) consumeLoop() {
 			slog.Info("Stopping Kafka consumer for lambda", "lambda", lkc.lambdaName)
 			return
 		default:
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(common.Conf.Kafka.Poll_timeout_sec)*time.Second)
 			fetches := lkc.client.PollFetches(ctx)
 			cancel()
 

--- a/go/worker/event/kafkaServer_test.go
+++ b/go/worker/event/kafkaServer_test.go
@@ -17,7 +17,15 @@ import (
 
 func TestMain(m *testing.M) {
 	// Initialize common.Conf so that common.T0/T1 (latency tracking) doesn't panic
-	common.Conf = &common.Config{}
+	common.Conf = &common.Config{
+		Kafka: common.KafkaConfig{
+			Cache_enabled:          true,
+			Cache_size:             1024,
+			Session_timeout_sec:    10,
+			Heartbeat_interval_sec: 3,
+			Poll_timeout_sec:       1,
+		},
+	}
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
This adds the following config options and defaults to the worker side Kafka config:
  - cache_enabled: true
  - cache_size: 1024
  - session_timeout_sec: 10
  - heartbeat_interval_sec: 3
  - poll_timeout_sec: 1
