### PR TITLE
allow systemd to delegate a scope to ol for managing cgroups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       run: cargo install cross --locked
     - name: Build OpenLambda
       run: |
-        make ol imgs/ol-wasm wasm-worker wasm-functions native-functions container-proxy
+        make ol-bin imgs/ol-wasm wasm-worker wasm-functions native-functions container-proxy
         make install-python-bindings
         make sudo-install
     - name: Test Go Common

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -47,7 +47,7 @@ jobs:
       run: cargo install cross --locked
     - name: Build OpenLambda
       run: |
-        make ol imgs/lambda wasm-worker wasm-functions native-functions container-proxy
+        make ol-bin imgs/lambda wasm-worker wasm-functions native-functions container-proxy
         sudo make install-python-bindings
     - name: Test PyPI Packages
       run: sudo ./scripts/package_tests.py

--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,7 @@
 /test.json
 
 # binaries
-ol
+ol-bin
 ol-wasm
 ol-container-proxy
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ endif
 .PHONY: container-proxy
 .PHONY: fmt check-fmt
 
-all: ol imgs/ol-wasm wasm-worker wasm-functions native-functions container-proxy
+all: ol-bin imgs/ol-wasm wasm-worker wasm-functions native-functions container-proxy
 
 wasm-worker:
 	cd wasm-worker && cargo build ${BUILD_FLAGS}
@@ -76,10 +76,10 @@ container-proxy:
 	cd container-proxy && cargo build ${BUILD_FLAGS}
 	cp ./container-proxy/target/${BUILDTYPE}/open-lambda-container-proxy ./ol-container-proxy
 
-ol: ${OL_GO_FILES}
+ol-bin: ${OL_GO_FILES}
 	cd ${OL_DIR} && ${GO} build -o ../ol-bin
 
-build: ol wasm-worker container-proxy
+build: ol-bin wasm-worker container-proxy
 
 install: build
 	cp ol ${INSTALL_PREFIX}/bin/
@@ -129,6 +129,6 @@ lint-wasm-worker:
 lint: lint-wasm-worker lint-functions lint-python lint-go
 
 clean:
-	rm -f ol imgs/ol-min imgs/ol-wasm
+	rm -f ol-bin imgs/ol-min imgs/ol-wasm
 	${MAKE} -C lambda clean
 	${MAKE} -C sock clean

--- a/Makefile
+++ b/Makefile
@@ -77,18 +77,20 @@ container-proxy:
 	cp ./container-proxy/target/${BUILDTYPE}/open-lambda-container-proxy ./ol-container-proxy
 
 ol: ${OL_GO_FILES}
-	cd ${OL_DIR} && ${GO} build -o ../ol
+	cd ${OL_DIR} && ${GO} build -o ../ol-bin
 
 build: ol wasm-worker container-proxy
 
 install: build
 	cp ol ${INSTALL_PREFIX}/bin/
+	cp ol-bin ${INSTALL_PREFIX}/bin/
 	cp ol-wasm ${INSTALL_PREFIX}/bin/
 	cp ol-container-proxy ${INSTALL_PREFIX}/bin/
 	cp autocomplete/bash_autocomplete /etc/bash_completion.d/ol 
 
 sudo-install: build
 	sudo cp ol ${INSTALL_PREFIX}/bin/
+	sudo cp ol-bin ${INSTALL_PREFIX}/bin/
 	sudo cp ol-wasm ${INSTALL_PREFIX}/bin/
 	sudo cp ol-container-proxy ${INSTALL_PREFIX}/bin/
 	sudo cp autocomplete/bash_autocomplete /etc/bash_completion.d/ol 

--- a/go/common/cgroup.go
+++ b/go/common/cgroup.go
@@ -1,0 +1,24 @@
+package common
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func CgroupRoot() (string, error) {
+	if Conf != nil && Conf.Cgroup_root != "" {
+		return Conf.Cgroup_root, nil
+	}
+	data, err := os.ReadFile("/proc/self/cgroup")
+	if err != nil {
+		return "", fmt.Errorf("read /proc/self/cgroup: %w", err)
+	}
+	line := strings.TrimSpace(string(data))
+	parts := strings.SplitN(line, "::", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("unexpected /proc/self/cgroup format: %q", line)
+	}
+	return filepath.Join("/sys/fs/cgroup", parts[1]), nil
+}

--- a/go/common/cgroup.go
+++ b/go/common/cgroup.go
@@ -7,6 +7,17 @@ import (
 	"strings"
 )
 
+// EnsureCgroupConfigured fails if neither cgroup_root nor OL_SYSTEMD is set.
+func EnsureCgroupConfigured() error {
+	if Conf != nil && Conf.Cgroup_root != "" {
+		return nil
+	}
+	if os.Getenv("OL_SYSTEMD") == "1" {
+		return nil
+	}
+	return fmt.Errorf("no cgroup root: set cgroup_root in config or run the worker via 'ol'")
+}
+
 func CgroupRoot() (string, error) {
 	if Conf != nil && Conf.Cgroup_root != "" {
 		return Conf.Cgroup_root, nil

--- a/go/common/config.go
+++ b/go/common/config.go
@@ -21,6 +21,9 @@ type Config struct {
 	// worker directory, which contains handler code, pid file, logs, etc.
 	Worker_dir string `json:"worker_dir"`
 
+	// configure the cgroup pool root - defaults to '/proc/self/cgroup'
+	Cgroup_root string `json:"cgroup_root"`
+
 	// Url/ip the worker server listens to
 	Worker_url string `json:"worker_url"`
 

--- a/go/common/config.go
+++ b/go/common/config.go
@@ -492,8 +492,3 @@ func GetOlPath(ctx *cli.Context) (string, error) {
 	}
 	return filepath.Abs(olPath)
 }
-
-// CgroupPoolPath returns the cgroup pool root path for the given OL directory.
-func CgroupPoolPath(olPath string) string {
-	return filepath.Join("/sys/fs/cgroup", filepath.Base(olPath)+"-sandboxes")
-}

--- a/go/worker/commands.go
+++ b/go/worker/commands.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/open-lambda/open-lambda/go/common"
 	"github.com/open-lambda/open-lambda/go/worker/event"
-	"github.com/open-lambda/open-lambda/go/worker/sandbox/cgroups"
 
 	"github.com/urfave/cli/v2"
 )
@@ -40,27 +39,18 @@ func udsGet(requestPath string) (*http.Response, error) {
 
 // initCmd corresponds to the "init" command of the admin tool.
 func initCmd(ctx *cli.Context) error {
-	if os.Getuid() != 0 {
-		return fmt.Errorf("'ol worker init' must be run with sudo")
-	}
-
 	olPath, err := common.GetOlPath(ctx)
 	if err != nil {
-		return fmt.Errorf("init failed to get OL path: %w", err)
+		return err
 	}
 
 	if err := common.LoadDefaults(olPath); err != nil {
-		return fmt.Errorf("init failed to load config defaults: %w", err)
+		return err
 	}
 
 	if err := initOLDir(olPath, ctx.String("image"), ctx.Bool("newbase")); err != nil {
-		return fmt.Errorf("init failed to create OL directory: %w", err)
+		return err
 	}
-
-	if err := cgroups.InitPoolRoot(common.CgroupPoolPath(olPath)); err != nil {
-		return fmt.Errorf("init failed to create cgroup pool: %w", err)
-	}
-
 	fmt.Printf("\nYou may optionally modify the defaults here: %s\n\n",
 		filepath.Join(olPath, "config.json"))
 	fmt.Printf("Next start a worker using the \"ol worker up\" command.\n")

--- a/go/worker/helpers.go
+++ b/go/worker/helpers.go
@@ -315,7 +315,7 @@ func stoppedDirtyToStoppedClean(olPath string) error {
 				}
 				if err := syscall.Rmdir(cg); err != nil {
 					// Print an error if removing a cgroup fails.
-					fmt.Printf("could not remove cgroup: %s", err.Error())
+					fmt.Printf("could not remove cgroup: %s\n", err.Error())
 					cgroupErrorCount += 1
 				}
 			}

--- a/go/worker/helpers.go
+++ b/go/worker/helpers.go
@@ -280,7 +280,10 @@ func runningToStoppedClean() error {
 // Returns errors encountered during cleanup operations.
 func stoppedDirtyToStoppedClean(olPath string) error {
 	// Clean up cgroups associated with sandboxes
-	cgRoot := filepath.Join("/sys", "fs", "cgroup", filepath.Base(olPath)+"-sandboxes")
+	cgRoot, err := common.CgroupRoot()
+	if err != nil {
+		return fmt.Errorf("failed to resolve cgroup root: %s", err)
+	}
 	fmt.Printf("Attempting to clean up cgroups at %s\n", cgRoot)
 
 	cgroupErrorCount := 0
@@ -300,16 +303,16 @@ func stoppedDirtyToStoppedClean(olPath string) error {
 		if err != nil {
 			return fmt.Errorf("error reading cgroup root: %s", err.Error())
 		}
-		kill := filepath.Join(cgRoot, "cgroup.kill")
-		if err := os.WriteFile(kill, []byte(fmt.Sprintf("%d", 1)), os.ModeAppend); err != nil {
-			// Print an error if killing processes in the cgroup fails.
-			fmt.Printf("Could not kill processes in cgroup: %s\n", err.Error())
-			cgroupErrorCount += 1
-		}
 		for _, file := range files {
 			if strings.HasPrefix(file.Name(), "cg-") {
 				cg := filepath.Join(cgRoot, file.Name())
 				fmt.Printf("Attempting to remove %s\n", cg)
+				kill := filepath.Join(cg, "cgroup.kill")
+				if err := os.WriteFile(kill, []byte(fmt.Sprintf("%d", 1)), os.ModeAppend); err != nil {
+					// Print an error if killing processes in the cgroup fails.
+					fmt.Printf("Could not kill processes in cgroup: %s\n", err.Error())
+					cgroupErrorCount += 1
+				}
 				if err := syscall.Rmdir(cg); err != nil {
 					// Print an error if removing a cgroup fails.
 					fmt.Printf("could not remove cgroup: %s", err.Error())
@@ -317,11 +320,8 @@ func stoppedDirtyToStoppedClean(olPath string) error {
 				}
 			}
 		}
-		if err := syscall.Rmdir(cgRoot); err != nil {
-			// Print an error if removing the cgroup root directory fails.
-			fmt.Printf("could not remove cgroup root: %s", err.Error())
-			cgroupErrorCount += 1
-		}
+		_ = syscall.Rmdir(filepath.Join(cgRoot, "worker"))
+		_ = syscall.Rmdir(cgRoot)
 	}
 
 	sandboxErrorCount := 0

--- a/go/worker/helpers.go
+++ b/go/worker/helpers.go
@@ -280,6 +280,9 @@ func runningToStoppedClean() error {
 // Returns errors encountered during cleanup operations.
 func stoppedDirtyToStoppedClean(olPath string) error {
 	// Clean up cgroups associated with sandboxes
+	if err := common.EnsureCgroupConfigured(); err != nil {
+		return err
+	}
 	cgRoot, err := common.CgroupRoot()
 	if err != nil {
 		return fmt.Errorf("failed to resolve cgroup root: %s", err)

--- a/go/worker/helpers.go
+++ b/go/worker/helpers.go
@@ -21,7 +21,6 @@ import (
 	"github.com/open-lambda/open-lambda/go/worker/embedded"
 )
 
-
 func initOLBaseDir(baseDir string, dockerBaseImage string) error {
 	if dockerBaseImage == "" {
 		dockerBaseImage = "ol-wasm"
@@ -280,8 +279,8 @@ func runningToStoppedClean() error {
 // It cleans up cgroups and mounts associated with the OpenLambda instance at `olPath`.
 // Returns errors encountered during cleanup operations.
 func stoppedDirtyToStoppedClean(olPath string) error {
-	// Clean up child cgroups, preserving the pool root
-	cgRoot := common.CgroupPoolPath(olPath)
+	// Clean up cgroups associated with sandboxes
+	cgRoot := filepath.Join("/sys", "fs", "cgroup", filepath.Base(olPath)+"-sandboxes")
 	fmt.Printf("Attempting to clean up cgroups at %s\n", cgRoot)
 
 	cgroupErrorCount := 0
@@ -303,6 +302,7 @@ func stoppedDirtyToStoppedClean(olPath string) error {
 		}
 		kill := filepath.Join(cgRoot, "cgroup.kill")
 		if err := os.WriteFile(kill, []byte(fmt.Sprintf("%d", 1)), os.ModeAppend); err != nil {
+			// Print an error if killing processes in the cgroup fails.
 			fmt.Printf("Could not kill processes in cgroup: %s\n", err.Error())
 			cgroupErrorCount += 1
 		}
@@ -311,10 +311,16 @@ func stoppedDirtyToStoppedClean(olPath string) error {
 				cg := filepath.Join(cgRoot, file.Name())
 				fmt.Printf("Attempting to remove %s\n", cg)
 				if err := syscall.Rmdir(cg); err != nil {
-					fmt.Printf("could not remove cgroup: %s\n", err.Error())
+					// Print an error if removing a cgroup fails.
+					fmt.Printf("could not remove cgroup: %s", err.Error())
 					cgroupErrorCount += 1
 				}
 			}
+		}
+		if err := syscall.Rmdir(cgRoot); err != nil {
+			// Print an error if removing the cgroup root directory fails.
+			fmt.Printf("could not remove cgroup root: %s", err.Error())
+			cgroupErrorCount += 1
 		}
 	}
 

--- a/go/worker/sandbox/cgroups/cgroup.go
+++ b/go/worker/sandbox/cgroups/cgroup.go
@@ -78,9 +78,9 @@ func (cg *CgroupImpl) Destroy() {
 	}
 }
 
-// GroupPath returns the path to this cgroup directory.
+// GroupPath returns the path to the Cgroup pool for OpenLambda
 func (cg *CgroupImpl) GroupPath() string {
-	return fmt.Sprintf("%s/%s", cg.pool.poolPath, cg.name)
+	return fmt.Sprintf("%s/%s", cg.pool.GroupPath(), cg.name)
 }
 
 func (cg *CgroupImpl) MemoryEvents() map[string]int64 {
@@ -107,7 +107,7 @@ func (cg *CgroupImpl) MemoryEvents() map[string]int64 {
 
 // ResourcePath returns the path to a specific resource in this cgroup
 func (cg *CgroupImpl) ResourcePath(resource string) string {
-	return fmt.Sprintf("%s/%s/%s", cg.pool.poolPath, cg.name, resource)
+	return fmt.Sprintf("%s/%s/%s", cg.pool.GroupPath(), cg.name, resource)
 }
 
 func (cg *CgroupImpl) TryWriteInt(resource string, val int64) error {

--- a/go/worker/sandbox/cgroups/pool.go
+++ b/go/worker/sandbox/cgroups/pool.go
@@ -1,14 +1,15 @@
 package cgroups
 
 import (
+	"errors"
 	"fmt"
-	"io/ioutil"
 	"log/slog"
 	"os"
 	"path"
+	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/open-lambda/open-lambda/go/common"
 )
@@ -18,34 +19,79 @@ import (
 const CGROUP_RESERVE = 16
 
 type CgroupPool struct {
-	Name     string
-	ready    chan *CgroupImpl
-	recycled chan *CgroupImpl
-	quit     chan chan bool
-	nextID   int
+	Name       string
+	parentPath string
+	ready      chan *CgroupImpl
+	recycled   chan *CgroupImpl
+	quit       chan chan bool
+	nextID     int
 }
 
 // NewCgroupPool creates a new CgroupPool with the specified name.
-func NewCgroupPool(name string) (*CgroupPool, error) {
+func NewCgroupPool(name, parentPath string) (*CgroupPool, error) {
 	pool := &CgroupPool{
-		Name:     path.Base(path.Dir(common.Conf.Worker_dir)) + "-" + name,
-		ready:    make(chan *CgroupImpl, CGROUP_RESERVE),
-		recycled: make(chan *CgroupImpl, CGROUP_RESERVE),
-		quit:     make(chan chan bool),
-		nextID:   0,
+		Name:       path.Base(path.Dir(common.Conf.Worker_dir)) + "-" + name,
+		parentPath: parentPath,
+		ready:      make(chan *CgroupImpl, CGROUP_RESERVE),
+		recycled:   make(chan *CgroupImpl, CGROUP_RESERVE),
+		quit:       make(chan chan bool),
+		nextID:     0,
 	}
 
-	// create cgroup
-	groupPath := pool.GroupPath()
-	pool.printf("create %s", groupPath)
-	if err := syscall.Mkdir(groupPath, 0700); err != nil {
-		return nil, fmt.Errorf("Mkdir %s: %s", groupPath, err)
+	pool.printf("using parent cgroup %s", parentPath)
+
+	// create cgroup pool parent - no-op if already exists
+	if err := os.MkdirAll(parentPath, 0700); err != nil {
+		return nil, fmt.Errorf("mkdir %s: %w", parentPath, err)
 	}
 
-	// Make controllers available to child groups
-	rpath := fmt.Sprintf("%s/cgroup.subtree_control", groupPath)
-	if err := ioutil.WriteFile(rpath, []byte("+pids +io +memory +cpu"), os.ModeAppend); err != nil {
-		panic(fmt.Sprintf("Error writing to %s: %v", rpath, err))
+	// enumerate controllers delegated to the parent
+	ctrlData, err := os.ReadFile(filepath.Join(parentPath, "cgroup.controllers"))
+	if err != nil {
+		return nil, fmt.Errorf("read %s/cgroup.controllers: %w", parentPath, err)
+	}
+	available := strings.Fields(string(ctrlData))
+
+	// require cpu, memory, pids
+	for _, req := range []string{"cpu", "memory", "pids"} {
+		if !slices.Contains(available, req) {
+			return nil, fmt.Errorf(
+				"cannot delegate required cgroup controller %q to %s (available: %v); ",
+				req, parentPath, available,
+			)
+		}
+	}
+
+	// move self pid to worker cgroup before enabling subtree_control
+	workerPath := filepath.Join(parentPath, "worker")
+	if err := os.Mkdir(workerPath, 0700); err != nil && !os.IsExist(err) {
+		return nil, fmt.Errorf("mkdir %s: %w", workerPath, err)
+	}
+	// migrate every pid in parent to worker/ - --detach leaves >1 in the scope
+	parentProcs, err := os.ReadFile(filepath.Join(parentPath, "cgroup.procs"))
+	if err != nil {
+		return nil, fmt.Errorf("read %s/cgroup.procs: %w", parentPath, err)
+	}
+	workerProcsPath := filepath.Join(workerPath, "cgroup.procs")
+	for _, pidStr := range strings.Fields(string(parentProcs)) {
+		// pid exited between read and write - ignore
+		if err := os.WriteFile(workerProcsPath, []byte(pidStr), 0); err != nil && !errors.Is(err, syscall.ESRCH) {
+			return nil, fmt.Errorf("move pid %s into %s: %w", pidStr, workerPath, err)
+		}
+	}
+
+	// enable every available controller on parent's subtree_control
+	var enable strings.Builder
+	for i, c := range available {
+		if i > 0 {
+			enable.WriteByte(' ')
+		}
+		enable.WriteByte('+')
+		enable.WriteString(c)
+	}
+	subPath := filepath.Join(parentPath, "cgroup.subtree_control")
+	if err := os.WriteFile(subPath, []byte(enable.String()), 0); err != nil {
+		return nil, fmt.Errorf("enable controllers at %s: %w", subPath, err)
 	}
 
 	go pool.cgTask()
@@ -142,22 +188,7 @@ func (pool *CgroupPool) Destroy() {
 	ch := make(chan bool)
 	pool.quit <- ch
 	<-ch
-
-	// Destroy cgroup for this entire pool
-	gpath := pool.GroupPath()
-	pool.printf("Destroying cgroup pool with path \"%s\"", gpath)
-	for i := 100; i >= 0; i-- {
-		if err := syscall.Rmdir(gpath); err != nil {
-			if i == 0 {
-				panic(fmt.Errorf("Rmdir %s: %s", gpath, err))
-			}
-
-			pool.printf("cgroup pool Rmdir failed, trying again in 5ms")
-			time.Sleep(5 * time.Millisecond)
-		} else {
-			break
-		}
-	}
+	pool.printf("cgroup pool drained")
 }
 
 // GetCg retrieves a cgroup from the pool, setting its memory limit and CPU percentage.
@@ -181,5 +212,5 @@ func (pool *CgroupPool) GetCg(memLimitMB int, moveMemCharge bool, cpuPercent int
 
 // GroupPath returns the path to the Cgroup pool for OpenLambda
 func (pool *CgroupPool) GroupPath() string {
-	return fmt.Sprintf("/sys/fs/cgroup/%s", pool.Name)
+	return pool.parentPath
 }

--- a/go/worker/sandbox/cgroups/pool.go
+++ b/go/worker/sandbox/cgroups/pool.go
@@ -2,12 +2,13 @@ package cgroups
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log/slog"
 	"os"
-	"path/filepath"
-	"strconv"
+	"path"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/open-lambda/open-lambda/go/common"
 )
@@ -18,56 +19,35 @@ const CGROUP_RESERVE = 16
 
 type CgroupPool struct {
 	Name     string
-	poolPath string
 	ready    chan *CgroupImpl
 	recycled chan *CgroupImpl
 	quit     chan chan bool
 	nextID   int
 }
 
-// InitPoolRoot creates the cgroup pool root directory and enables controllers.
-func InitPoolRoot(poolPath string) error {
-
-	if err := os.MkdirAll(poolPath, 0700); err != nil {
-		return fmt.Errorf("failed to create cgroup pool root %s: %w", poolPath, err)
-	}
-
-	ctrlPath := filepath.Join(poolPath, "cgroup.subtree_control")
-	if err := os.WriteFile(ctrlPath, []byte("+pids +io +memory +cpu"), os.ModeAppend); err != nil {
-		return fmt.Errorf("failed to enable controllers at %s: %w", ctrlPath, err)
-	}
-
-	uidStr := os.Getenv("SUDO_UID")
-	if uidStr == "" {
-		return fmt.Errorf("SUDO_UID not set; worker must be run with sudo")
-	}
-	uid, err := strconv.Atoi(uidStr)
-	if err != nil {
-		return fmt.Errorf("invalid SUDO_UID value %q: %w", uidStr, err)
-	}
-	if err := os.Chown(poolPath, uid, uid); err != nil {
-		return fmt.Errorf("failed to chown cgroup pool root: %w", err)
-	}
-
-	fmt.Printf("\tCreated cgroup pool root at %s\n", poolPath)
-	return nil
-}
-
-func NewCgroupPool(name string, poolPath string) (*CgroupPool, error) {
+// NewCgroupPool creates a new CgroupPool with the specified name.
+func NewCgroupPool(name string) (*CgroupPool, error) {
 	pool := &CgroupPool{
-		Name:     name,
-		poolPath: poolPath,
+		Name:     path.Base(path.Dir(common.Conf.Worker_dir)) + "-" + name,
 		ready:    make(chan *CgroupImpl, CGROUP_RESERVE),
 		recycled: make(chan *CgroupImpl, CGROUP_RESERVE),
 		quit:     make(chan chan bool),
 		nextID:   0,
 	}
 
-	if st, err := os.Stat(poolPath); err != nil || !st.IsDir() {
-		return nil, fmt.Errorf("cgroup pool root %s does not exist.", poolPath)
+	// create cgroup
+	groupPath := pool.GroupPath()
+	pool.printf("create %s", groupPath)
+	if err := syscall.Mkdir(groupPath, 0700); err != nil {
+		return nil, fmt.Errorf("Mkdir %s: %s", groupPath, err)
 	}
 
-	pool.printf("reusing pool root %s", poolPath)
+	// Make controllers available to child groups
+	rpath := fmt.Sprintf("%s/cgroup.subtree_control", groupPath)
+	if err := ioutil.WriteFile(rpath, []byte("+pids +io +memory +cpu"), os.ModeAppend); err != nil {
+		panic(fmt.Sprintf("Error writing to %s: %v", rpath, err))
+	}
+
 	go pool.cgTask()
 	return pool, nil
 }
@@ -156,14 +136,28 @@ Empty:
 	done <- true
 }
 
-// Destroy drains all child cgroups but preserves the pool root.
+// Destroy this entire cgroup pool
 func (pool *CgroupPool) Destroy() {
 	// signal cgTask, then wait for it to finish
 	ch := make(chan bool)
 	pool.quit <- ch
 	<-ch
 
-	pool.printf("destroyed all child cgroups, pool root preserved")
+	// Destroy cgroup for this entire pool
+	gpath := pool.GroupPath()
+	pool.printf("Destroying cgroup pool with path \"%s\"", gpath)
+	for i := 100; i >= 0; i-- {
+		if err := syscall.Rmdir(gpath); err != nil {
+			if i == 0 {
+				panic(fmt.Errorf("Rmdir %s: %s", gpath, err))
+			}
+
+			pool.printf("cgroup pool Rmdir failed, trying again in 5ms")
+			time.Sleep(5 * time.Millisecond)
+		} else {
+			break
+		}
+	}
 }
 
 // GetCg retrieves a cgroup from the pool, setting its memory limit and CPU percentage.
@@ -183,4 +177,9 @@ func (pool *CgroupPool) GetCg(memLimitMB int, moveMemCharge bool, cpuPercent int
 		}*/
 
 	return cg
+}
+
+// GroupPath returns the path to the Cgroup pool for OpenLambda
+func (pool *CgroupPool) GroupPath() string {
+	return fmt.Sprintf("/sys/fs/cgroup/%s", pool.Name)
 }

--- a/go/worker/sandbox/cgroups/pool.go
+++ b/go/worker/sandbox/cgroups/pool.go
@@ -19,36 +19,36 @@ import (
 const CGROUP_RESERVE = 16
 
 type CgroupPool struct {
-	Name       string
-	parentPath string
-	ready      chan *CgroupImpl
-	recycled   chan *CgroupImpl
-	quit       chan chan bool
-	nextID     int
+	Name     string
+	poolPath string
+	ready    chan *CgroupImpl
+	recycled chan *CgroupImpl
+	quit     chan chan bool
+	nextID   int
 }
 
 // NewCgroupPool creates a new CgroupPool with the specified name.
-func NewCgroupPool(name, parentPath string) (*CgroupPool, error) {
+func NewCgroupPool(name, poolPath string) (*CgroupPool, error) {
 	pool := &CgroupPool{
-		Name:       path.Base(path.Dir(common.Conf.Worker_dir)) + "-" + name,
-		parentPath: parentPath,
-		ready:      make(chan *CgroupImpl, CGROUP_RESERVE),
-		recycled:   make(chan *CgroupImpl, CGROUP_RESERVE),
-		quit:       make(chan chan bool),
-		nextID:     0,
+		Name:     path.Base(path.Dir(common.Conf.Worker_dir)) + "-" + name,
+		poolPath: poolPath,
+		ready:    make(chan *CgroupImpl, CGROUP_RESERVE),
+		recycled: make(chan *CgroupImpl, CGROUP_RESERVE),
+		quit:     make(chan chan bool),
+		nextID:   0,
 	}
 
-	pool.printf("using parent cgroup %s", parentPath)
+	pool.printf("using parent cgroup %s", poolPath)
 
 	// create cgroup pool parent - no-op if already exists
-	if err := os.MkdirAll(parentPath, 0700); err != nil {
-		return nil, fmt.Errorf("mkdir %s: %w", parentPath, err)
+	if err := os.MkdirAll(poolPath, 0700); err != nil {
+		return nil, fmt.Errorf("mkdir %s: %w", poolPath, err)
 	}
 
 	// enumerate controllers delegated to the parent
-	ctrlData, err := os.ReadFile(filepath.Join(parentPath, "cgroup.controllers"))
+	ctrlData, err := os.ReadFile(filepath.Join(poolPath, "cgroup.controllers"))
 	if err != nil {
-		return nil, fmt.Errorf("read %s/cgroup.controllers: %w", parentPath, err)
+		return nil, fmt.Errorf("read %s/cgroup.controllers: %w", poolPath, err)
 	}
 	available := strings.Fields(string(ctrlData))
 
@@ -57,24 +57,24 @@ func NewCgroupPool(name, parentPath string) (*CgroupPool, error) {
 		if !slices.Contains(available, req) {
 			return nil, fmt.Errorf(
 				"cannot delegate required cgroup controller %q to %s (available: %v); ",
-				req, parentPath, available,
+				req, poolPath, available,
 			)
 		}
 	}
 
 	// move self pid to worker cgroup before enabling subtree_control
-	workerPath := filepath.Join(parentPath, "worker")
+	workerPath := filepath.Join(poolPath, "worker")
 	if err := os.Mkdir(workerPath, 0700); err != nil && !os.IsExist(err) {
 		return nil, fmt.Errorf("mkdir %s: %w", workerPath, err)
 	}
 	// migrate every pid in parent to worker/ - --detach leaves >1 in the scope
-	parentProcs, err := os.ReadFile(filepath.Join(parentPath, "cgroup.procs"))
+	parentProcs, err := os.ReadFile(filepath.Join(poolPath, "cgroup.procs"))
 	if err != nil {
-		return nil, fmt.Errorf("read %s/cgroup.procs: %w", parentPath, err)
+		return nil, fmt.Errorf("read %s/cgroup.procs: %w", poolPath, err)
 	}
 	workerProcsPath := filepath.Join(workerPath, "cgroup.procs")
 	for _, pidStr := range strings.Fields(string(parentProcs)) {
-		// pid exited between read and write - ignore
+		// ESRCH: pid exited between read and write - ignore
 		if err := os.WriteFile(workerProcsPath, []byte(pidStr), 0); err != nil && !errors.Is(err, syscall.ESRCH) {
 			return nil, fmt.Errorf("move pid %s into %s: %w", pidStr, workerPath, err)
 		}
@@ -89,7 +89,7 @@ func NewCgroupPool(name, parentPath string) (*CgroupPool, error) {
 		enable.WriteByte('+')
 		enable.WriteString(c)
 	}
-	subPath := filepath.Join(parentPath, "cgroup.subtree_control")
+	subPath := filepath.Join(poolPath, "cgroup.subtree_control")
 	if err := os.WriteFile(subPath, []byte(enable.String()), 0); err != nil {
 		return nil, fmt.Errorf("enable controllers at %s: %w", subPath, err)
 	}
@@ -212,5 +212,5 @@ func (pool *CgroupPool) GetCg(memLimitMB int, moveMemCharge bool, cpuPercent int
 
 // GroupPath returns the path to the Cgroup pool for OpenLambda
 func (pool *CgroupPool) GroupPath() string {
-	return pool.parentPath
+	return pool.poolPath
 }

--- a/go/worker/sandbox/sockPool.go
+++ b/go/worker/sandbox/sockPool.go
@@ -34,6 +34,9 @@ type SOCKPool struct {
 
 // NewSOCKPool creates a SOCKPool.
 func NewSOCKPool(name string, mem *MemPool) (cf *SOCKPool, err error) {
+	if err := common.EnsureCgroupConfigured(); err != nil {
+		return nil, err
+	}
 	poolPath, err := common.CgroupRoot()
 	if err != nil {
 		return nil, fmt.Errorf("discover cgroup root: %w", err)

--- a/go/worker/sandbox/sockPool.go
+++ b/go/worker/sandbox/sockPool.go
@@ -34,11 +34,11 @@ type SOCKPool struct {
 
 // NewSOCKPool creates a SOCKPool.
 func NewSOCKPool(name string, mem *MemPool) (cf *SOCKPool, err error) {
-	parentPath, err := common.CgroupRoot()
+	poolPath, err := common.CgroupRoot()
 	if err != nil {
 		return nil, fmt.Errorf("discover cgroup root: %w", err)
 	}
-	cgPool, err := cgroups.NewCgroupPool(name, parentPath)
+	cgPool, err := cgroups.NewCgroupPool(name, poolPath)
 	if err != nil {
 		return nil, err
 	}

--- a/go/worker/sandbox/sockPool.go
+++ b/go/worker/sandbox/sockPool.go
@@ -34,8 +34,7 @@ type SOCKPool struct {
 
 // NewSOCKPool creates a SOCKPool.
 func NewSOCKPool(name string, mem *MemPool) (cf *SOCKPool, err error) {
-	olPath := filepath.Dir(common.Conf.Worker_dir)
-	cgPool, err := cgroups.NewCgroupPool(name, common.CgroupPoolPath(olPath))
+	cgPool, err := cgroups.NewCgroupPool(name)
 	if err != nil {
 		return nil, err
 	}

--- a/go/worker/sandbox/sockPool.go
+++ b/go/worker/sandbox/sockPool.go
@@ -34,7 +34,11 @@ type SOCKPool struct {
 
 // NewSOCKPool creates a SOCKPool.
 func NewSOCKPool(name string, mem *MemPool) (cf *SOCKPool, err error) {
-	cgPool, err := cgroups.NewCgroupPool(name)
+	parentPath, err := common.CgroupRoot()
+	if err != nil {
+		return nil, fmt.Errorf("discover cgroup root: %w", err)
+	}
+	cgPool, err := cgroups.NewCgroupPool(name, parentPath)
 	if err != nil {
 		return nil, err
 	}

--- a/ol
+++ b/ol
@@ -1,7 +1,7 @@
 #!/bin/sh
 BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
 if command -v systemd-run >/dev/null 2>&1; then
-	exec systemd-run --quiet --scope -p Delegate=yes "${BIN_DIR}/ol-bin" "$@"
+	exec systemd-run --quiet --scope -p Delegate=yes --setenv=OL_SYSTEMD=1 "${BIN_DIR}/ol-bin" "$@"
 fi
-echo "warning: systemd-run not found; running without delegated scope." >&2
+echo "warning: systemd-run not found; cgroup_root must be set in config." >&2
 exec "${BIN_DIR}/ol-bin" "$@"

--- a/ol
+++ b/ol
@@ -3,5 +3,5 @@ BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
 if command -v systemd-run >/dev/null 2>&1; then
 	exec systemd-run --quiet --scope -p Delegate=yes "${BIN_DIR}/ol-bin" "$@"
 fi
-echo "warning: systemd-run not found; running without delegated scope - cgroup_root must be set in config.json" >&2
+echo "warning: systemd-run not found; running without delegated scope." >&2
 exec "${BIN_DIR}/ol-bin" "$@"

--- a/ol
+++ b/ol
@@ -1,0 +1,7 @@
+#!/bin/sh
+BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+if command -v systemd-run >/dev/null 2>&1; then
+	exec systemd-run --quiet --scope -p Delegate=yes "${BIN_DIR}/ol-bin" "$@"
+fi
+echo "warning: systemd-run not found; running without delegated scope - cgroup_root must be set in config.json" >&2
+exec "${BIN_DIR}/ol-bin" "$@"


### PR DESCRIPTION
- The worker now executes via "ol", a wrapper around the actual binary "ol-bin". This wrapper tries to execute ol with systemd-run so systemd can allocate a transient scope to ol to manage its cgroups.
- The admin can set a custom cgroups root path in the config, which will be used incase systemd doesn't exist, or the admin wants to manage their own cgroups in their way.

Manual Testing Flow:
<img width="1271" height="1205" alt="image" src="https://github.com/user-attachments/assets/b111dbca-bf05-4bb5-a031-98f57ec7377a" />
